### PR TITLE
Run fopub once to download gradle wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ MAINTAINER Guillaume Scheibel <guillaume.scheibel@gmail.com>
 
 RUN yum install -y tar make gcc ruby ruby-devel rubygems graphviz rubygem-nokogiri asciidoctor
 RUN (curl -s -k -L -C - -b "oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u20-b26/jdk-8u20-linux-x64.tar.gz | tar xfz -)
-RUN mkdir /fopub && curl -L https://api.github.com/repos/asciidoctor/asciidoctor-fopub/tarball | tar xzf - -C /fopub/ --strip-components=1
 ENV JAVA_HOME /jdk1.8.0_20
 ENV PATH $PATH:$JAVA_HOME/bin:/fopub/bin
 ENV BACKENDS /asciidoctor-backends
+# Install fopub and run it once on a fake file to download the gradle wrapper
+RUN mkdir /fopub && curl -L https://api.github.com/repos/asciidoctor/asciidoctor-fopub/tarball | tar xzf - -C /fopub/ --strip-components=1 && \
+    touch empty.xml && fopub empty.xml && rm empty.xml
 
 RUN gem install --no-ri --no-rdoc asciidoctor-diagram && \
     gem install --no-ri --no-rdoc asciidoctor-epub3 --version 1.0.0.alpha.2 && \


### PR DESCRIPTION
First, great work with this image, very handy!

Using fopub, the gradle wrapper will be downloaded every time a new container is started, which slows the process. This PR is a naive attempt to run it once during the build to avoid that.

It creates an empty file, run the fopub command on it, and delete the file. The command will fail as it is not a correct docbook file, but we don't care as it achieve the purpose of installing everything needed to run fopub immediately when a container is started. If you have a better idea, of course disregard this PR.