### PR TITLE
Single layer install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ ENV JAVA_HOME /jdk1.8.0_20
 ENV PATH $PATH:$JAVA_HOME/bin:/fopub/bin
 ENV BACKENDS /asciidoctor-backends
 
-COPY gvm/config /root/.gvm/etc/
-
 RUN yum install -y tar \
     make \
     gcc \
@@ -46,6 +44,7 @@ RUN yum install -y tar \
   && easy_install actdiag \
   && easy_install nwdiag \
   && (curl -s get.gvmtool.net | bash) \
+  && echo "gvm_auto_answer=true" | tee -a /root/.gvm/etc/config \
   && /bin/bash -c "source /root/.gvm/bin/gvm-init.sh" \
   && /bin/bash -c -l gvm install lazybones
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,54 @@
-FROM fedora
+FROM fedora:22
+
 MAINTAINER Guillaume Scheibel <guillaume.scheibel@gmail.com>
 
-RUN yum install -y tar make gcc ruby ruby-devel rubygems graphviz rubygem-nokogiri asciidoctor unzip findutils which wget python-devel zlib-devel
-RUN (curl -s -k -L -C - -b "oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u20-b26/jdk-8u20-linux-x64.tar.gz | tar xfz -)
+WORKDIR /documents
+
 ENV JAVA_HOME /jdk1.8.0_20
 ENV PATH $PATH:$JAVA_HOME/bin:/fopub/bin
 ENV BACKENDS /asciidoctor-backends
-# Install fopub and run it once on a fake file to download the gradle wrapper
-RUN mkdir /fopub && curl -L https://api.github.com/repos/asciidoctor/asciidoctor-fopub/tarball | tar xzf - -C /fopub/ --strip-components=1 && \
-    touch empty.xml && fopub empty.xml && rm empty.xml
 
-RUN gem install --no-ri --no-rdoc asciidoctor-diagram && \
-    gem install --no-ri --no-rdoc asciidoctor-epub3 --version 1.0.0.alpha.2 && \
-    gem install --no-ri --no-rdoc asciidoctor-pdf --version 1.5.0.alpha.7 && \
-    gem install --no-ri --no-rdoc asciidoctor-confluence && \
-    gem install --no-ri --no-rdoc coderay pygments.rb thread_safe epubcheck kindlegen && \
-    gem install --no-ri --no-rdoc slim && \
-    gem install --no-ri --no-rdoc haml tilt && \
-    mkdir /documents && \
-    mkdir $BACKENDS && \
-    (curl -LkSs https://api.github.com/repos/asciidoctor/asciidoctor-backends/tarball | tar xfz - -C $BACKENDS --strip-components=1)
+COPY gvm/config /root/.gvm/etc/
 
-# Install blockdiag, seqdiag, actdiag and nwdiag diagram tools
-RUN wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py -O - | python
-RUN easy_install "blockdiag[pdf]"
-RUN easy_install seqdiag
-RUN easy_install actdiag
-RUN easy_install nwdiag
+RUN yum install -y tar \
+    make \
+    gcc \
+    ruby \
+    ruby-devel \
+    rubygems \
+    graphviz \
+    rubygem-nokogiri \
+    asciidoctor \
+    unzip \
+    findutils \
+    which \
+    wget \
+    python-devel \
+    zlib-devel \
+  && (curl -s -k -L -C - -b "oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u20-b26/jdk-8u20-linux-x64.tar.gz | tar xfz -) \
+  && mkdir /fopub \
+  && curl -L https://api.github.com/repos/asciidoctor/asciidoctor-fopub/tarball | tar xzf - -C /fopub/ --strip-components=1 \
+  && touch empty.xml \
+  && fopub empty.xml \
+  && rm empty.xml \
+  && gem install --no-ri --no-rdoc asciidoctor-diagram \
+  && gem install --no-ri --no-rdoc asciidoctor-epub3 --version 1.0.0.alpha.2 \
+  && gem install --no-ri --no-rdoc asciidoctor-pdf --version 1.5.0.alpha.7 \
+  && gem install --no-ri --no-rdoc asciidoctor-confluence \
+  && gem install --no-ri --no-rdoc coderay pygments.rb thread_safe epubcheck kindlegen \
+  && gem install --no-ri --no-rdoc slim \
+  && gem install --no-ri --no-rdoc haml tilt \
+  && mkdir $BACKENDS \
+  && (curl -LkSs https://api.github.com/repos/asciidoctor/asciidoctor-backends/tarball | tar xfz - -C $BACKENDS --strip-components=1) \
+  && wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py -O - | python \
+  && easy_install "blockdiag[pdf]" \
+  && easy_install seqdiag \
+  && easy_install actdiag \
+  && easy_install nwdiag \
+  && (curl -s get.gvmtool.net | bash) \
+  && /bin/bash -c "source /root/.gvm/bin/gvm-init.sh" \
+  && /bin/bash -c -l gvm install lazybones
 
-RUN (curl -s get.gvmtool.net | bash)
-RUN ["/bin/bash", "-c", "source /root/.gvm/bin/gvm-init.sh"]
-ADD gvm/config /root/.gvm/etc/
-RUN ["/bin/bash", "-c", "-l", "gvm install lazybones"]
-
-WORKDIR /documents
 VOLUME /documents
 
 CMD ["/bin/bash"]

--- a/gvm/config
+++ b/gvm/config
@@ -1,1 +1,0 @@
-gvm_auto_answer=true


### PR DESCRIPTION
Fewer layers = more performances.

Although, how can we control the version of asciidoctor as it is installed via yum instead of a rubygem?

Ideally it could also fit in the asciidoctor repo to benefit from the Docker Hub auto-build feature.