### PR TITLE
Asciidoctor 1.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,26 @@
 FROM fedora
 MAINTAINER Guillaume Scheibel <guillaume.scheibel@gmail.com>
 
-RUN yum install -y tar make gcc ruby ruby-devel rubygems graphviz rubygem-nokogiri asciidoctor unzip findutils which wget python-devel zlib-devel
+ENV ASCIIDOCTOR_VERSION "1.5.3"
+
+RUN yum install -y tar make gcc ruby ruby-devel rubygems graphviz rubygem-nokogiri unzip findutils which wget python-devel zlib-devel
 RUN (curl -s -k -L -C - -b "oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u20-b26/jdk-8u20-linux-x64.tar.gz | tar xfz -)
 ENV JAVA_HOME /jdk1.8.0_20
 ENV PATH $PATH:$JAVA_HOME/bin:/fopub/bin
 ENV BACKENDS /asciidoctor-backends
 # Install fopub and run it once on a fake file to download the gradle wrapper
 RUN mkdir /fopub && curl -L https://api.github.com/repos/asciidoctor/asciidoctor-fopub/tarball | tar xzf - -C /fopub/ --strip-components=1 && \
-    touch empty.xml && fopub empty.xml && rm empty.xml
+    touch empty.xml && fopub empty.xml && rm empty.xml \
+    echo "gem: --no-document" | tee -a ~/.gemrc
 
-RUN gem install --no-ri --no-rdoc asciidoctor-diagram && \
-    gem install --no-ri --no-rdoc asciidoctor-epub3 --version 1.0.0.alpha.2 && \
-    gem install --no-ri --no-rdoc asciidoctor-pdf --version 1.5.0.alpha.7 && \
-    gem install --no-ri --no-rdoc asciidoctor-confluence && \
-    gem install --no-ri --no-rdoc coderay pygments.rb thread_safe epubcheck kindlegen && \
-    gem install --no-ri --no-rdoc slim && \
-    gem install --no-ri --no-rdoc haml tilt && \
+RUN gem install asciidoctor --version ${ASCIIDOCTOR_VERSION} && \
+    gem install asciidoctor-diagram && \
+    gem install asciidoctor-epub3 --version 1.0.0.alpha.2 && \
+    gem install asciidoctor-pdf --version 1.5.0.alpha.7 && \
+    gem install asciidoctor-confluence && \
+    gem install coderay pygments.rb thread_safe epubcheck kindlegen && \
+    gem install slim && \
+    gem install haml tilt && \
     mkdir /documents && \
     mkdir $BACKENDS && \
     (curl -LkSs https://api.github.com/repos/asciidoctor/asciidoctor-backends/tarball | tar xfz - -C $BACKENDS --strip-components=1)


### PR DESCRIPTION
- explicit version if stated as part of the Dockerfile (easier to trigger per tag auto-builds on Docker Hub)
- install from Gemfile rather than Fedora system package (release cycle might be different and does not bring much value to it)