### PR TITLE
WiP : Moving to Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,32 @@
-FROM fedora
+FROM alpine:3.3
 
 MAINTAINER Guillaume Scheibel <guillaume.scheibel@gmail.com>
+MAINTAINER Damien DUPORTAL <damien.duportal@gmail.com>
 
-ENV JAVA_HOME /jdk1.8.0_20
-ENV PATH $PATH:$JAVA_HOME/bin:/fopub/bin
+ENV JAVA_HOME /usr/lib/jvm/default-jvm
+ENV PATH ${PATH}:${JAVA_HOME}/bin:/fopub/bin
 ENV BACKENDS /asciidoctor-backends
 ENV GVM_AUTO_ANSWER true
 ENV ASCIIDOCTOR_VERSION "1.5.4"
 
-RUN dnf install -y tar \
-    make \
-    gcc \
-    ruby \
-    ruby-devel \
-    rubygems \
+RUN apk --update add \
+    bash \
+    build-base \
+    curl \
     graphviz \
-    rubygem-nokogiri \
+    openjdk8 \
+    python \
+    python-dev \
+    py-pillow \
+    ruby \
+    ruby-dev \
+    ruby-nokogiri \
+    tar \
+    ttf-liberation \
     unzip \
-    findutils \
-    which \
-    wget \
-    python-devel \
-    zlib-devel \
-    libjpeg-devel \
-    redhat-rpm-config \
-    patch \
-  && dnf clean packages \
-  && (curl -s -k -L -C - -b "oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u20-b26/jdk-8u20-linux-x64.tar.gz | tar xfz -) \
+    zlib \
   && mkdir /fopub \
-  && curl -L https://api.github.com/repos/asciidoctor/asciidoctor-fopub/tarball | tar xzf - -C /fopub/ --strip-components=1 \
+  && curl -L -s https://api.github.com/repos/asciidoctor/asciidoctor-fopub/tarball | tar xzf - -C /fopub/ --strip-components=1 \
   && touch empty.xml \
   && fopub empty.xml \
   && rm empty.xml \
@@ -42,7 +40,7 @@ RUN dnf install -y tar \
   && gem install --no-ri --no-rdoc haml tilt \
   && mkdir $BACKENDS \
   && (curl -LkSs https://api.github.com/repos/asciidoctor/asciidoctor-backends/tarball | tar xfz - -C $BACKENDS --strip-components=1) \
-  && wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py -O - | python \
+  && curl -L -s https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py | python \
   && easy_install "blockdiag[pdf]" \
   && easy_install seqdiag \
   && easy_install actdiag \
@@ -50,7 +48,14 @@ RUN dnf install -y tar \
   && (curl -s get.sdkman.io | bash) \
   && /bin/bash -c "source /root/.sdkman/bin/sdkman-init.sh" \
   && /bin/bash -c "echo sdkman_auto_answer=true > ~/.sdkman/etc/config" \
-  && /bin/bash -c -l "sdk install lazybones"
+  && /bin/bash -c -l "sdk install lazybones" \
+  && apk del -r \
+    build-base \
+    curl \
+    python-dev \
+    ruby-dev \
+    unzip \
+  && rm -rf /var/cache/apk/*
 
 WORKDIR /documents
 VOLUME /documents

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:latest
 
 MAINTAINER Guillaume Scheibel <guillaume.scheibel@gmail.com>
 MAINTAINER Damien DUPORTAL <damien.duportal@gmail.com>

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apk --update add \
   && gem install --no-ri --no-rdoc haml tilt \
   && mkdir $BACKENDS \
   && (curl -LkSs https://api.github.com/repos/asciidoctor/asciidoctor-backends/tarball | tar xfz - -C $BACKENDS --strip-components=1) \
+  && (curl -LkSs https://api.github.com/repos/asciidoctor/asciidoctor-reveal.js/tarball | tar xfz - -C /asciidoctor-backends/slim/revealjs/ --strip-components=3) \
   && curl -L -s https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py | python \
   && easy_install "blockdiag[pdf]" \
   && easy_install seqdiag \
@@ -56,6 +57,9 @@ RUN apk --update add \
     ruby-dev \
     unzip \
   && rm -rf /var/cache/apk/*
+
+RUN rm /asciidoctor-backends/slim/revealjs/README.adoc
+RUN rm /asciidoctor-backends/slim/dzslides/README.adoc
 
 WORKDIR /documents
 VOLUME /documents


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL damien.duportal@gmail.com

Hi all ! This is PR is still WiP, since I want to integrate tests before all.

The idea is to make the image the most ligthweight as possible, since 1.6 Gb is just too much (and also run it inside a Raspberry Pi :) )

Regarding the approaching shift to alpine for the "Docker Hub base" images - https://news.ycombinator.com/item?id=11044980 , I think it would be a great fit.

I successed by doing some thing, but since I'm a newcomer in the AsciiDoctor area, I need help for testing ! (Even with https://github.com/asciidoctor/docker-asciidoctor/pull/23 )

Here is my current result of "Virtual Size" : 

```
MacBook-Pro-de-Dadou:docker-asciidoctor dadou$ docker images | grep ascii
docker-asciidoctor   alpine              0a6f67fdcafe        28 hours ago        706.4 MB
docker-asciidoctor   latest              441783b36ecf        2 days ago          1.453 GB
```

Half the size !

Some problems encountered (and solved) : 
- When moving to OpenJDK 8, I lost the dynamic link to Sun font-stuff. But there is an apk package for that : `ttf-liberation`
- On Linux Alpine, the package for having kernel headers, gcc, make, etc. is named `build-base`
- Since Python's pillow and Ruby's Nokogiri are still always annoying-to-install libraries, there is an apk package for them :)
- curl seems a different version than Fedora : I had to "silent" it to not mess with the `curl ... | tar`archive downloads.

Please try it and tell we if it is working ?
