### PR TITLE
Added sudo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN dnf install -y tar \
     libjpeg-devel \
     redhat-rpm-config \
     patch \
+    sudo \
   && dnf clean packages \
   && (curl -s -k -L -C - -b "oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u20-b26/jdk-8u20-linux-x64.tar.gz | tar xfz -) \
   && mkdir /fopub \


### PR DESCRIPTION
Just `sudo` so people can instantiate `asciidoctor` in the container as the user they are running their stuff.

E.g. a script such as `asciidoctor.sh` is impossible to write:

```sh
PROJECT_FOLDER=$(pwd)

docker run --rm \
    -v $PROJECT_FOLDER:/documents \
    -v /etc/passwd:/etc/passwd:ro \
    -v /etc/group:/etc/group:ro \
    asciidoctor/docker-asciidoctor \
    /usr/bin/sudo -E -u "#$(id -u)" "/usr/local/bin/asciidoctor" "$@"
```
