### PR TITLE
Dockerfile +epubcheck +kindlegen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN dnf install -y tar \
   && gem install --no-ri --no-rdoc asciidoctor --version $ASCIIDOCTOR_VERSION \
   && gem install --no-ri --no-rdoc asciidoctor-diagram \
   && gem install --no-ri --no-rdoc asciidoctor-epub3 --version 1.5.0.alpha.6 \
+  && gem install --no-ri --no-rdoc rake \
+  && gem install --no-ri --no-rdoc epubcheck --version 3.0.1 \
+  && gem install --no-ri --no-rdoc kindlegen --version 3.0.1 \
   && gem install --no-ri --no-rdoc asciidoctor-pdf --version 1.5.0.alpha.13 \
   && gem install --no-ri --no-rdoc asciidoctor-confluence \
   && gem install --no-ri --no-rdoc rouge coderay pygments.rb thread_safe epubcheck kindlegen \


### PR DESCRIPTION
epubcheck and kindlegen now have gem installs available. I forget which, but I needed rake on my ubuntu laptop to get one of these to install.