### PR TITLE
Re-include "make"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache \
     curl \
     ca-certificates \
     findutils \
+    make \
     py2-pillow \
     python2 \
     ruby \

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -30,6 +30,10 @@ teardown() {
   docker run -t --rm "${DOCKER_IMAGE_NAME}" which asciidoctor-pdf
 }
 
+@test "make is installed and in the path" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME}" which make
+}
+
 @test "asciidoctor-epub3 is installed and in the path" {
   docker run -t --rm "${DOCKER_IMAGE_NAME}" which asciidoctor-epub3
 }


### PR DESCRIPTION
PR #39 which moved the image to alpine has also thrown out make, which is quite handy for more complicated build scenarios.