### PR TITLE
Fix #44: Re-Enabling Asciidoctor-diagram usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apk add --no-cache \
     curl \
     ca-certificates \
     findutils \
+    graphviz \
+    openjdk8-jre \
     py2-pillow \
     python2 \
     ruby \

--- a/tests/fixtures/sample-with-diagram.adoc
+++ b/tests/fixtures/sample-with-diagram.adoc
@@ -1,0 +1,16 @@
+
+= Sample
+
+This is a sample from
+link:https://github.com/asciidoctor/docker-asciidoctor/issues/44#issue-265179207[]
+
+[IMPORTANT]
+====
+Thanks to link:https://github.com/ryosms[]!
+====
+
+[plantuml,sample-diagram,svg]
+----
+class Sample {
+}
+----

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -5,7 +5,8 @@ TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
 ASCIIDOCTOR_VERSION="1.5.5"
 
 clean_generated_files() {
-  rm -rf "${TMP_GENERATION_DIR}"
+  docker run -t --rm -v "${BATS_TEST_DIRNAME}:${BATS_TEST_DIRNAME}" alpine \
+    rm -rf "${TMP_GENERATION_DIR}"
 }
 
 setup() {

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -38,11 +38,24 @@ teardown() {
   docker run -t --rm "${DOCKER_IMAGE_NAME}" which curl
 }
 
+@test "bash is installed and in the path" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME}" which bash
+}
+
+@test "java is installed, in the path, and executable" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME}" which java
+  docker run -t --rm "${DOCKER_IMAGE_NAME}" java -version
+}
+
+@test "dot (from Graphviz) is installed and in the path" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME}" which dot
+}
+
 @test "asciidoctor-confluence is installed and in the path" {
   docker run -t --rm "${DOCKER_IMAGE_NAME}" which asciidoctor-confluence
 }
 
-@test "We can generate a HTML document from basic example" {
+@test "We can generate an HTML document from basic example" {
   docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
     "${DOCKER_IMAGE_NAME}" \
@@ -57,4 +70,22 @@ teardown() {
     "${DOCKER_IMAGE_NAME}" \
       asciidoctor-pdf -D /documents/tmp -r asciidoctor-mathematical \
       /documents/fixtures/basic-example.adoc
+}
+
+@test "We can generate an HTML document with a diagram with asciidoctor-diagram as backend" {
+  run docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME}" \
+      asciidoctor -D /documents/tmp -r asciidoctor-diagram \
+      /documents/fixtures/sample-with-diagram.adoc
+
+  # Even when in ERROR with the module, asciidoctor return 0 because a document
+  # has been generated
+  [ "${status}" -eq 0 ]
+
+  echo "-- Output of command:"
+  echo "${output}"
+  echo "--"
+
+  [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
 }


### PR DESCRIPTION
The Pull Request #39 broke the usage of Asciidoctor-diagram.

This pull request aims to fix it, by introducing the following:

- A sample from #44 has been added to validate usage and provide non-regression in future upgrades
- 3 test cases have been introduced to cover the tools that where missing
- Install OpenJDK8-JRE (not the full JDK: I might miss something but we just want to execute with Java)
- Install Graphviz, required for generating diagrams

[EDIT]
The image is built (and updated) on the DockerHub and can be pulled without building it:
```bash
docker pull dduportal/docker-asciidoctor:fix-adoc-diagram
```