### PR TITLE
Asciidoctor upgraded to 1.5.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM alpine:3.6
 
 LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 
-# Check https://pkgs.alpinelinux.org/packages?name=asciidoctor&branch=&repo=&arch=&maintainer=
-ENV ASCIIDOCTOR_VERSION="1.5.5-r1"
+ARG ASCIIDOCTOR_VERSION="1.5.5"
+ENV asciidoctor_version=${ASCIIDOCTOR_VERSION}
 
 RUN apk add --no-cache \
-    asciidoctor="${ASCIIDOCTOR_VERSION}" \
     bash \
     curl \
     ca-certificates \
@@ -26,6 +25,7 @@ RUN apk add --no-cache \
     python2-dev \
     py2-pip \
     ruby-dev \
+  && gem install --no-document asciidoctor --version "${asciidoctor_version}" \
   && gem install --no-document asciidoctor-epub3 --version 1.5.0.alpha.7 \
   && gem install --no-document asciidoctor-pdf --version 1.5.0.alpha.15 \
   && gem install --no-document epubcheck --version 3.0.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6
 
 LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 
-ARG ASCIIDOCTOR_VERSION="1.5.5"
+ARG ASCIIDOCTOR_VERSION="1.5.6"
 ENV asciidoctor_version=${ASCIIDOCTOR_VERSION}
 
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6
 
 LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 
-ARG ASCIIDOCTOR_VERSION="1.5.6"
+ARG ASCIIDOCTOR_VERSION="1.5.6.1"
 ENV asciidoctor_version=${ASCIIDOCTOR_VERSION}
 
 RUN apk add --no-cache \

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -2,7 +2,7 @@
 
 DOCKER_IMAGE_NAME="docker-asciidoctor:test"
 TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
-ASCIIDOCTOR_VERSION="1.5.5"
+ASCIIDOCTOR_VERSION="1.5.6"
 
 clean_generated_files() {
   rm -rf "${TMP_GENERATION_DIR}"

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -2,7 +2,7 @@
 
 DOCKER_IMAGE_NAME="docker-asciidoctor:test"
 TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
-ASCIIDOCTOR_VERSION="1.5.6"
+ASCIIDOCTOR_VERSION="1.5.6.1"
 
 clean_generated_files() {
   rm -rf "${TMP_GENERATION_DIR}"


### PR DESCRIPTION
This Pull Request aims to provide an upgrade of asciidoctor to the version 1.5.6.1.

This is the implementation for the issue #43.

It introduces the following changes:

* Installing Asciidoctor with `gem` instead of using the Alpine package, since the lifecycles  are different
* Upgrading to the latest Asciidoctor v1.5.6.1 (instead of 1.5.5)

You can test with the prebuilt image from Docker Hub:

```bash
docker pull dduportal/docker-asciidoctor:adoc-gem-and-156
```