### PR TITLE
Upgrading asciidoctor-pdf to 1.5.0.alpha.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
     ruby-dev \
   && gem install --no-document asciidoctor --version "${asciidoctor_version}" \
   && gem install --no-document asciidoctor-epub3 --version 1.5.0.alpha.7 \
-  && gem install --no-document asciidoctor-pdf --version 1.5.0.alpha.15 \
+  && gem install --no-document asciidoctor-pdf --version 1.5.0.alpha.16 \
   && gem install --no-document epubcheck --version 3.0.1 \
   && gem install --no-document kindlegen --version 3.0.3 \
   && gem install --no-document asciidoctor-revealjs \

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 
 This Docker container provides:
 
-* Asciidoctor 1.5.5
+* Asciidoctor 1.5.6.1
 * Aciidoctor Diagram with Graphviz integration so you can use plantuml and graphiz diagrams
 * Asciidoctor PDF (alpha)
 * Asciidoctor EPUB3 (alpha)
@@ -95,5 +95,5 @@ way of testing, it is included.
 
 [source,bash]
 ----
-bats ./tests/test_suite.bats 
+bats ./tests/test_suite.bats
 ----

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -3,6 +3,7 @@
 DOCKER_IMAGE_NAME="docker-asciidoctor:test"
 TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
 ASCIIDOCTOR_VERSION="1.5.6.1"
+ASCIIDOCTOR_PDF_VERSION="1.5.0.alpha.16"
 
 clean_generated_files() {
   docker run -t --rm -v "${BATS_TEST_DIRNAME}:${BATS_TEST_DIRNAME}" alpine \
@@ -27,8 +28,10 @@ teardown() {
     | grep "Asciidoctor" | grep "${ASCIIDOCTOR_VERSION}"
 }
 
-@test "asciidoctor-pdf is installed and in the path" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which asciidoctor-pdf
+@test "asciidoctor-pdf is installed and in version ${ASCIIDOCTOR_PDF_VERSION}" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME}" asciidoctor-pdf -v \
+    | grep "Asciidoctor PDF" | grep "${ASCIIDOCTOR_VERSION}" \
+    | grep "${ASCIIDOCTOR_PDF_VERSION}"
 }
 
 @test "make is installed and in the path" {


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>

This Pull request introduces the following changes:

- asciidoctor-pdf updated to 1.5.0.alpha.16 (with prawn-svg to 0.27.1 has stated in https://github.com/asciidoctor/asciidoctor-pdf/releases/tag/v1.5.0.alpha.16 )
- a test has been improved to check asciidoctor-pdf version
- README fixed for the asciidoctor version


Build on TravisCI: https://travis-ci.org/dduportal/docker-asciidoctor/builds/291461280