### PR TITLE
[Gh-55] Fix fonts to have a correct rendering of mathematical generated images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 tests/tmp/
+tests/fixtures/generated_images/
+tests/*.pdf
+tests/*.html
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apk add --no-cache \
     ttf-liberation \
     unzip \
     which \
+  && apk add --no-cache \
+    --repository https://nl.alpinelinux.org/alpine/edge/testing \
+    font-bakoma-ttf \
   && apk add --no-cache --virtual .makedepends \
     build-base \
     libxml2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
     unzip \
     which \
   && apk add --no-cache \
-    --repository https://nl.alpinelinux.org/alpine/edge/testing \
+    --repository https://nl.alpinelinux.org/alpine/edge/community \
     font-bakoma-ttf \
   && apk add --no-cache --virtual .makedepends \
     build-base \

--- a/tests/fixtures/sample-with-latex-math.adoc
+++ b/tests/fixtures/sample-with-latex-math.adoc
@@ -1,0 +1,23 @@
+= Precompiled Math
+:math:
+:imagesoutdir: generated_images
+:imagesdir: images
+:stem: latexmath
+
+Sample example, courtesy of link:https://github.com/philwinder[@philwinder].
+
+== Equations in normal blocks
+
+[latexmath]
+++++
+k_{n+1} = n^2 + k_n^2 - k_{n-1}
+++++
+
+Some useful text!
+
+Formula for quadratic root:
+
+[latexmath]
+++++
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+++++

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -97,3 +97,43 @@ teardown() {
 
   [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
 }
+
+@test "Bakoma Fonts are installed to render correctly the square root from asciidoctor-mathematical" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME}" apk info font-bakoma-ttf
+}
+
+@test "We can generate an HTML document with asciidoctor-mathematical as backend" {
+  run docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME}" \
+      asciidoctor -D /documents/tmp -r asciidoctor-mathematical \
+      /documents/fixtures/sample-with-latex-math.adoc
+
+  # Even when in ERROR with the module, asciidoctor return 0 because a document
+  # has been generated
+  [ "${status}" -eq 0 ]
+
+  echo "-- Output of command:"
+  echo "${output}"
+  echo "--"
+
+  [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
+}
+
+@test "We can generate a PDF document with asciidoctor-mathematical as backend" {
+  run docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME}" \
+      asciidoctor-pdf -D /documents/tmp -r asciidoctor-mathematical \
+      /documents/fixtures/sample-with-latex-math.adoc
+
+  # Even when in ERROR with the module, asciidoctor return 0 because a document
+  # has been generated
+  [ "${status}" -eq 0 ]
+
+  echo "-- Output of command:"
+  echo "${output}"
+  echo "--"
+
+  [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
+}


### PR DESCRIPTION
This Pull Request introduce the following changes:

* Fixing #55 by installing the bakoma fonts (provided by the documentation https://github.com/gjtorikian/mathematical#fonts-and-special-notices-for-mac-os-x). Thanks @philwinder for doing this
  - Fonts had to be packaged in Alpine Linux repository. Thanks, @jirutka for that! The APK is on the edge/testing repository, we'll use the "main" stable one as soon as it will be available.

You can test this image by using `dduportal/docker-asciidoctor:gh-55` from the DockerHub:

* DockerHub build log: https://hub.docker.com/r/dduportal/docker-asciidoctor/builds/bovmerdsprwjpmwasfawech/
* Travis CI related build and test: https://travis-ci.org/dduportal/docker-asciidoctor/builds/301347544