### PR TITLE
GH-49: Implementation proposal for CI and CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ script:
 - make build
 - make test
 
-deploy:
-- provider: script
-  script: make deploy
 # Do not deploy if Pull Request
 # If a contributor want to deploy on its own DockerHub account:
 # 1 - Enable Travis on the forked repository
 # 2 - Set the environment variable DOCKERHUB_USERNAME in Travis Settings
+deploy:
+- provider: script
+  script: make deploy
   on:
     condition: $TRAVIS_PULL_REQUEST = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 sudo: required
 
 services:
-  - docker
+- docker
 
-script: bats ./tests/test_suite.bats
-#
-# deploy:
-#   provider: script
-#   script: curl -H "Content-Type: application/json" --data '{"build": true}' -X POST https://registry.hub.docker.com/u/dduportal/docker-asciidoctor/trigger/${DOCKER_HUB_TOKEN}/
+script:
+- make build
+- make test
+
+deploy:
+- provider: script
+  script: make deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: required
 services:
 - docker
 
+env:
+  global:
+    - CURRENT_GIT_BRANCH=$TRAVIS_BRANCH
+
 script:
 - make build
 - make test
@@ -10,3 +14,9 @@ script:
 deploy:
 - provider: script
   script: make deploy
+# Do not deploy if Pull Request
+# If a contributor want to deploy on its own DockerHub account:
+# 1 - Enable Travis on the forked repository
+# 2 - Set the environment variable DOCKERHUB_USERNAME in Travis Settings
+  on:
+    condition: $TRAVIS_PULL_REQUEST = false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+
+DOCKER_IMAGE_NAME ?= docker-asciidoctor
+DOCKER_IMAGE_TEST_TAG ?= $(shell git rev-parse --short HEAD)
+DOCKER_IMAGE_NAME_TO_TEST ?= $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TEST_TAG)
+ASCIIDOCTOR_VERSION ?= 1.5.6.1
+ASCIIDOCTOR_PDF_VERSION ?= 1.5.0.alpha.16
+CURRENT_GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+export DOCKER_IMAGE_NAME_TO_TEST ASCIIDOCTOR_VERSION ASCIIDOCTOR_PDF_VERSION
+
+all: build test deploy
+
+build:
+	docker build \
+		-t $(DOCKER_IMAGE_NAME_TO_TEST) \
+		-f Dockerfile \
+		$(CURDIR)/
+
+test:
+	bats $(CURDIR)/tests/*.bats
+
+deploy:
+	curl -H "Content-Type: application/json" \
+		--data '{"source_type": "Branch", "source_name": "$(CURRENT_GIT_BRANCH)"}' \
+		-X POST https://registry.hub.docker.com/u/dduportal/docker-asciidoctor/trigger/$(DOCKER_HUB_TOKEN)/
+
+.PHONY: all build test deploy

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 
 DOCKER_IMAGE_NAME ?= docker-asciidoctor
+DOCKERHUB_USERNAME ?= asciidoctor
 DOCKER_IMAGE_TEST_TAG ?= $(shell git rev-parse --short HEAD)
-DOCKER_IMAGE_NAME_TO_TEST ?= $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TEST_TAG)
+DOCKER_IMAGE_NAME_TO_TEST ?= $(DOCKERHUB_USERNAME)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TEST_TAG)
 ASCIIDOCTOR_VERSION ?= 1.5.6.1
 ASCIIDOCTOR_PDF_VERSION ?= 1.5.0.alpha.16
-CURRENT_GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+CURRENT_GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 export DOCKER_IMAGE_NAME_TO_TEST ASCIIDOCTOR_VERSION ASCIIDOCTOR_PDF_VERSION
 
@@ -22,6 +23,6 @@ test:
 deploy:
 	curl -H "Content-Type: application/json" \
 		--data '{"source_type": "Branch", "source_name": "$(CURRENT_GIT_BRANCH)"}' \
-		-X POST https://registry.hub.docker.com/u/dduportal/docker-asciidoctor/trigger/$(DOCKER_HUB_TOKEN)/
+		-X POST https://registry.hub.docker.com/u/$(DOCKERHUB_USERNAME)/$(DOCKER_IMAGE_NAME)/trigger/$(DOCKER_HUB_TOKEN)/
 
 .PHONY: all build test deploy

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -1,9 +1,8 @@
 #!/usr/bin/env bats
 
-DOCKER_IMAGE_NAME="docker-asciidoctor:test"
 TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
-ASCIIDOCTOR_VERSION="1.5.6.1"
-ASCIIDOCTOR_PDF_VERSION="1.5.0.alpha.16"
+
+export TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
 
 clean_generated_files() {
   docker run -t --rm -v "${BATS_TEST_DIRNAME}:${BATS_TEST_DIRNAME}" alpine \
@@ -20,53 +19,53 @@ teardown() {
 }
 
 @test "We can build successfully the standard Docker image" {
-  docker build -t "${DOCKER_IMAGE_NAME}" "${BATS_TEST_DIRNAME}/../"
+  docker build -t "${DOCKER_IMAGE_NAME_TO_TEST}" "${BATS_TEST_DIRNAME}/../"
 }
 
 @test "asciidoctor is installed and in version ${ASCIIDOCTOR_VERSION}" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" asciidoctor -v \
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" asciidoctor -v \
     | grep "Asciidoctor" | grep "${ASCIIDOCTOR_VERSION}"
 }
 
 @test "asciidoctor-pdf is installed and in version ${ASCIIDOCTOR_PDF_VERSION}" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" asciidoctor-pdf -v \
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" asciidoctor-pdf -v \
     | grep "Asciidoctor PDF" | grep "${ASCIIDOCTOR_VERSION}" \
     | grep "${ASCIIDOCTOR_PDF_VERSION}"
 }
 
 @test "make is installed and in the path" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which make
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" which make
 }
 
 @test "asciidoctor-epub3 is installed and in the path" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which asciidoctor-epub3
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" which asciidoctor-epub3
 }
 
 @test "curl is installed and in the path" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which curl
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" which curl
 }
 
 @test "bash is installed and in the path" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which bash
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" which bash
 }
 
 @test "java is installed, in the path, and executable" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which java
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" java -version
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" which java
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" java -version
 }
 
 @test "dot (from Graphviz) is installed and in the path" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which dot
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" which dot
 }
 
 @test "asciidoctor-confluence is installed and in the path" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" which asciidoctor-confluence
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" which asciidoctor-confluence
 }
 
 @test "We can generate an HTML document from basic example" {
   docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
-    "${DOCKER_IMAGE_NAME}" \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
       asciidoctor -D /documents/tmp -r asciidoctor-mathematical \
       /documents/fixtures/basic-example.adoc
   grep '<html' ${TMP_GENERATION_DIR}/*html
@@ -75,7 +74,7 @@ teardown() {
 @test "We can generate a PDF document from basic example" {
   docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
-    "${DOCKER_IMAGE_NAME}" \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
       asciidoctor-pdf -D /documents/tmp -r asciidoctor-mathematical \
       /documents/fixtures/basic-example.adoc
 }
@@ -83,7 +82,7 @@ teardown() {
 @test "We can generate an HTML document with a diagram with asciidoctor-diagram as backend" {
   run docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
-    "${DOCKER_IMAGE_NAME}" \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
       asciidoctor -D /documents/tmp -r asciidoctor-diagram \
       /documents/fixtures/sample-with-diagram.adoc
 
@@ -99,13 +98,13 @@ teardown() {
 }
 
 @test "Bakoma Fonts are installed to render correctly the square root from asciidoctor-mathematical" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" apk info font-bakoma-ttf
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" apk info font-bakoma-ttf
 }
 
 @test "We can generate an HTML document with asciidoctor-mathematical as backend" {
   run docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
-    "${DOCKER_IMAGE_NAME}" \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
       asciidoctor -D /documents/tmp -r asciidoctor-mathematical \
       /documents/fixtures/sample-with-latex-math.adoc
 
@@ -123,7 +122,7 @@ teardown() {
 @test "We can generate a PDF document with asciidoctor-mathematical as backend" {
   run docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
-    "${DOCKER_IMAGE_NAME}" \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
       asciidoctor-pdf -D /documents/tmp -r asciidoctor-mathematical \
       /documents/fixtures/sample-with-latex-math.adoc
 

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -34,7 +34,7 @@ teardown() {
 }
 
 @test "asciidoctor-revealjs is callable without error" {
-  docker run -t --rm "${DOCKER_IMAGE_NAME}" asciidoctor-revealjs -v
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" asciidoctor-revealjs -v
 }
 
 @test "make is installed and in the path" {


### PR DESCRIPTION
This Pull Request is a proposal implementation for #49 .

* It features the use of Travis-CI to build and test the docker-asciidoctor container
* GNU Make is used to provide a workflow
* Currently, the Deploy phase is proposed using my DockerHub account (https://hub.docker.com/r/dduportal/docker-asciidoctor/), to have a real life working example, with pushed images

*IMPORTANT* if this implementation of the deploy phase is fine, can someone with the right to the asciidoctor image on the DockerHub set up configuration or delegate to me the rights? The variable containing the token in https://travis-ci.org/asciidoctor/docker-asciidoctor/settings need to be adapted (as well as the curl destination in the deploy goal in this PR).

As side-kick setting, the `master` branch of this repository had been configured to be protected (need  CI check).

Ping @mojavelinux @mgreau , I would like your review and advise on this?
