### PR TITLE
Gh-59: moving from python 2 to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,14 @@ RUN apk add --no-cache \
     inotify-tools \
     make \
     openjdk8-jre \
-    py3-pillow \
     python3 \
+    py3-pillow \
     py3-setuptools \
     ruby \
     ruby-mathematical \
+    # ruby-pygments installs python2, it is required for now
+    ruby-pygments \
+    ruby-rake \
     ttf-liberation \
     ttf-dejavu \
     tzdata \
@@ -61,7 +64,6 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     haml \
     kindlegen:3.0.3 \
     pygments.rb \
-    rake \
     rouge \
     slim \
     thread_safe \
@@ -78,7 +80,6 @@ RUN apk add --no-cache --virtual .pythonmakedepends \
     actdiag \
     'blockdiag[pdf]' \
     nwdiag \
-    Pygments \
     seqdiag \
   && apk del -r --no-cache .pythonmakedepends
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ RUN apk add --no-cache \
     inotify-tools \
     make \
     openjdk8-jre \
-    py2-pillow \
-    py-setuptools \
-    python2 \
+    py3-pillow \
+    python3 \
+    py3-setuptools \
     ruby \
     ruby-mathematical \
     ttf-liberation \
@@ -72,10 +72,9 @@ RUN apk add --no-cache --virtual .rubymakedepends \
 # functionnalities as diagrams or syntax highligthing
 RUN apk add --no-cache --virtual .pythonmakedepends \
     build-base \
-    python2-dev \
-    py2-pip \
-  && pip install --upgrade pip \
-  && pip install --no-cache-dir \
+    python3-dev \
+    py3-pip \
+  && pip3 install --no-cache-dir \
     actdiag \
     'blockdiag[pdf]' \
     nwdiag \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,6 @@ RUN apk add --no-cache \
     py3-setuptools \
     ruby \
     ruby-mathematical \
-    # ruby-pygments installs python2, it is required for now
-    ruby-pygments \
     ruby-rake \
     ttf-liberation \
     ttf-dejavu \
@@ -63,7 +61,6 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     epubcheck:3.0.1 \
     haml \
     kindlegen:3.0.3 \
-    pygments.rb \
     rouge \
     slim \
     thread_safe \

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ This Docker container provides:
 * Asciidoctor EPUB3 (alpha)
 * Asciidoctor Mathematical
 * AsciiMath
-* Source highlighting using Rouge or CodeRay
+* Source highlighting using Rouge or CodeRay (Pygments not supported)
 * Asciidoctor Confluence
 
 == How to use it

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ This Docker container provides:
 * Asciidoctor EPUB3 (alpha)
 * Asciidoctor Mathematical
 * AsciiMath
-* Source highlighting using Rouge or CodeRay (Pygments not supported)
+* Source highlighting using Rouge or CodeRay (Pygments not supported in the default Docker image as only Python 3 is available)
 * Asciidoctor Confluence
 
 == How to use it

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ This Docker container provides:
 * Asciidoctor EPUB3 (alpha)
 * Asciidoctor Mathematical
 * AsciiMath
-* Source highlighting using CodeRay or Pygments
+* Source highlighting using Rouge or CodeRay
 * Asciidoctor Confluence
 
 == How to use it

--- a/README.md
+++ b/README.md
@@ -6,21 +6,19 @@ This Docker container provides:
 
   - Asciidoctor 2.0.10
 
-  - Asciidoctor Diagram 1.5.18 with Graphviz integration so you can use plantuml and graphiz diagrams
+  - Asciidoctor Diagram 1.5.18 with Graphviz integration (supports plantuml and graphiz diagrams)
 
   - Asciidoctor PDF 1.5.0.beta.5
 
   - Asciidoctor EPUB3 (alpha)
 
-  - Source highlighting using Rouge or CodeRay (Pygments not supported)
+  - Asciidoctor Mathematical
 
-  - Asciidoctor backends
+  - AsciiMath
 
-  - Asciidoctor-fopub
+  - Source highlighting using Rouge or CodeRay (Pygments not supported in the default Docker image as only Python 3 is available)
 
-  - Asciidoctor-confluence
-
-  - Lazybones (for Asciidoctor-revealjs)
+  - Asciidoctor Confluence
 
 ## How to use it
 
@@ -32,10 +30,10 @@ docker run -it -v <your directory>:/documents/ asciidoctor/docker-asciidoctor
 
 It will be directly mapped with */documents* of the container.
 
-Once started, you just have to create AsciiDoc files (in the directory mentioned above) and run Asciidoctor commands like:
+Once started, you can use Asciidoctor commands to convert AsciiDoc files you created in the directory mentioned above. You can find several examples below.
 
   - To run Asciidoctor on a basic AsciiDoc file:
-
+    
     ``` bash
     asciidoctor sample.adoc
     asciidoctor-pdf sample.adoc
@@ -43,36 +41,21 @@ Once started, you just have to create AsciiDoc files (in the directory mentioned
     ```
 
   - To run AsciiDoc on an AsciiDoc file that contains diagrams:
-
+    
     ``` bash
     asciidoctor -r asciidoctor-diagram sample-with-diagram.adoc
     asciidoctor-pdf -r asciidoctor-diagram sample-with-diagram.adoc
     asciidoctor-epub3 -r asciidoctor-diagram sample-with-diagram.adoc
     ```
 
-  - To use Asciidoctor-backends use -T with either `/asciidoctor-backends` or `$BACKENDS` followed by the backend you want to use. For example:
-
-    ``` bash
-    asciidoctor -T /asciidoctor-backends/slim/dzslides myFile.adoc
-    #or
-    asciidoctor -T $BACKENDS/slim/dzslides myFile.adoc
-    ```
-
-  - To use fopub, you first need to generate the docbook file then use fopub:
-
-    ``` bash
-    asciidoctor -b docbook sample.adoc
-    fopub sample.xml
-    ```
-
-  - To use asciidoctor-confluence
-
+  - To use Asciidoctor Confluence:
+    
     ``` bash
     asciidoctor-confluence --host HOSTNAME --spaceKey SPACEKEY --title TITLE --username USER --password PASSWORD sample.adoc
     ```
 
   - Batch mode. You can use it in a "batch" mode
-
+    
     ``` bash
     docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf index.adoc
     ```
@@ -85,17 +68,28 @@ You need the following tools:
 
   - A bash compliant command line
 
+  - [GNU make](http://man7.org/linux/man-pages/man1/make.1.html)
+
   - [bats](https://github.com/sstephenson/bats) installed and in your bash PATH
 
   - Docker installed and in your path
 
 ### How to build and test ?
 
-  - "bats" is used as a test suite runner. Since the ability to build is one
-    way of testing, it is included.
+  - "bats" is used as a test suite runner. Since the ability to build is one way of testing, it is included.
 
   - You just have to run the bats test suite, from the repository root:
-
+    
     ``` bash
-    bats ./tests/test_suite.bats
+    make test
     ```
+
+#### Include test in your build pipeline or test manually
+
+You can use bats directly to test the image, optional you can use a custome image name:
+
+``` bash
+# If you want to use a custom name for the image, OPTIONAL
+export DOCKER_IMAGE_NAME_TO_TEST=your-image-name
+bats tests/*.bats
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Docker container provides:
 
   - Asciidoctor EPUB3 (alpha)
 
-  - Source highlighting using CodeRay or Pygments
+  - Source highlighting using Rouge or CodeRay
 
   - Asciidoctor backends
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Docker container provides:
 
   - Asciidoctor EPUB3 (alpha)
 
-  - Source highlighting using Rouge or CodeRay
+  - Source highlighting using Rouge or CodeRay (Pygments not supported)
 
   - Asciidoctor backends
 

--- a/tests/fixtures/epub-sample/asciidoctor-epub3-readme.adoc
+++ b/tests/fixtures/epub-sample/asciidoctor-epub3-readme.adoc
@@ -101,7 +101,7 @@ Of course, there's always room for improvement, so we'll continue to work with y
 * EPUB3 metadata, manifest and spine (assembled by Gepub)
 * Document metadata (title, authors, subject, keywords, etc.)
 * Internal cross reference links
-* Syntax highlighting with CodeRay or Pygments (must use inline styles)
+* Syntax highlighting with Rouge or CodeRay
 * Unicode callout numbers
 * Page breaks avoided in block content (so much as it's supported by the e-reader)
 * Orphan section titles avoided (so much as it's supported by the e-reader)
@@ -270,14 +270,14 @@ You can install the published gem using the following command:
 This optional environment variable tells the gem installer to link against the C libraries on the system, if available, instead of compiling the libraries from scratch.
 This speeds up the installation of Nokogiri considerably.
 
-If you want to syntax highlight source listings, you'll also want to install CodeRay or Pygments.
+If you want to syntax highlight source listings, you'll also want to install Rouge or CodeRay.
 Choose one (or more) of the following:
+
+.Rouge
+ $ gem install rouge
 
 .CodeRay
  $ gem install coderay
-
-.Pygments
- $ gem install pygments.rb
 
 You then activate syntax highlighting for a given document by adding the `source-highlighter` attribute to the document header (CodeRay shown):
 
@@ -285,11 +285,6 @@ You then activate syntax highlighting for a given document by adding the `source
 ----
 :source-highlighter: coderay
 ----
-
-NOTE: At the moment, Pygments is automatically used if it's available.
-If a style is not specified, the black and white theme (i.e., bw) is used.
-This default is used so that the syntax highlighting is legibile regardless of which reading mode the reader selects (white, black, sepia, etc).
-To override this default, you must pass a valid Pygments style name to the `pygments-style` attribute when invoking the `asciidoctor-epub3` script (e.g., `-a pygments-style=pastie`).
 
 Assuming all the required gems install properly, verify you can run the `asciidoctor-epub3` script:
 

--- a/tests/fixtures/epub-sample/sample-book.adoc
+++ b/tests/fixtures/epub-sample/sample-book.adoc
@@ -10,6 +10,7 @@ v1.0, 2014-04-15
 :idprefix:
 :idseparator: -
 :imagesdir: images
+:source-highlighter: coderay
 //:front-cover-image: image:front-cover.jpg[Front Cover,1050,1600]
 
 ifeval::["{scripts}" == "multilingual"]

--- a/tests/fixtures/samples-syntax-highlight/includes/app.rb
+++ b/tests/fixtures/samples-syntax-highlight/includes/app.rb
@@ -1,0 +1,4 @@
+require 'sinatra'
+get '/hi' do
+ "Hello World!"
+end

--- a/tests/fixtures/samples-syntax-highlight/includes/syntax-template.adoc
+++ b/tests/fixtures/samples-syntax-highlight/includes/syntax-template.adoc
@@ -1,0 +1,12 @@
+= Validating Syntax colorations
+
+A simple http://asciidoc.org[AsciiDoc] document for validating
+syntax coloration
+
+== Syntax Coloration with {source-highlighter}
+
+[source,ruby]
+.app.rb
+----
+include::./app.rb[]
+----

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-coderay.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-coderay.adoc
@@ -1,0 +1,4 @@
+
+:source-highlighter: coderay
+
+include::includes/syntax-template.adoc[]

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-highlightjs.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-highlightjs.adoc
@@ -1,0 +1,4 @@
+
+:source-highlighter: highlight.js
+
+include::includes/syntax-template.adoc[]

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-prettify.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-prettify.adoc
@@ -1,0 +1,4 @@
+
+:source-highlighter: pygments
+
+include::includes/syntax-template.adoc[]

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-prettify.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-prettify.adoc
@@ -1,4 +1,4 @@
 
-:source-highlighter: pygments
+:source-highlighter: prettify
 
 include::includes/syntax-template.adoc[]

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-pygments.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-pygments.adoc
@@ -1,0 +1,4 @@
+
+:source-highlighter: pygments
+
+include::includes/syntax-template.adoc[]

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-pygments.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-pygments.adoc
@@ -1,4 +1,0 @@
-
-:source-highlighter: pygments
-
-include::includes/syntax-template.adoc[]

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-rouge.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-rouge.adoc
@@ -1,0 +1,4 @@
+
+:source-highlighter: rouge
+
+include::includes/syntax-template.adoc[]

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -184,16 +184,16 @@ teardown() {
 
 @test "We can generate HTML documents with different syntax-colored codes" {
   docker run -t --rm \
-    -v "${BATS_TEST_DIRNAME}":/documents/ \
-    "${DOCKER_IMAGE_NAME}" \
-      asciidoctor -D /documents/tmp \
-      /documents/fixtures/samples-syntax-highlight/*.adoc
+  -v "${BATS_TEST_DIRNAME}":/documents/ \
+  "${DOCKER_IMAGE_NAME_TO_TEST}" \
+    asciidoctor --trace -D /documents/tmp -r asciidoctor-mathematical \
+    /documents/fixtures/samples-syntax-highlight/*.adoc
 }
 
 @test "We can generate PDF documents with different syntax-colored codes" {
   docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
-    "${DOCKER_IMAGE_NAME}" \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
       asciidoctor-pdf -D /documents/tmp \
       /documents/fixtures/samples-syntax-highlight/*.adoc
 }

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -179,6 +179,21 @@ teardown() {
 
   [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
 }
-
 # asciimath isn't tested with the PDF backend because it doesn't support stem blocks
 # without image rendering
+
+@test "We can generate HTML documents with different syntax-colored codes" {
+  docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME}" \
+      asciidoctor -D /documents/tmp \
+      /documents/fixtures/samples-syntax-highlight/*.adoc
+}
+
+@test "We can generate PDF documents with different syntax-colored codes" {
+  docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME}" \
+      asciidoctor-pdf -D /documents/tmp \
+      /documents/fixtures/samples-syntax-highlight/*.adoc
+}


### PR DESCRIPTION
This pull request aims at implementing #59 .

It introduces the following changes:

- Python, pip, and all related python tools are using the python 3 packages from Alpine, instead of the "legacy" python 2 ones.
- A test for syntax colors (as for pygments.rb) has been added.