### PR TITLE
Update pip to prevent warning of new version during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apk add --no-cache --virtual .pythonmakedepends \
     build-base \
     python2-dev \
     py2-pip \
-  &&␣pip␣install␣--upgrade␣pip␣\
+  && pip install --upgrade pip \
   && pip install --no-cache-dir \
     actdiag \
     'blockdiag[pdf]' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN apk add --no-cache --virtual .pythonmakedepends \
     build-base \
     python2-dev \
     py2-pip \
+  &&␣pip␣install␣--upgrade␣pip␣\
   && pip install --no-cache-dir \
     actdiag \
     'blockdiag[pdf]' \


### PR DESCRIPTION
Added pip update, because of warning message of new version during build