### PR TITLE
Add asciimath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     asciidoctor-diagram \
     asciidoctor-epub3:1.5.0.alpha.7 \
     asciidoctor-mathematical \
+    asciimath \
     "asciidoctor-pdf:${ASCIIDOCTOR_PDF_VERSION}" \
     asciidoctor-revealjs \
     coderay \

--- a/README.adoc
+++ b/README.adoc
@@ -9,6 +9,8 @@ This Docker container provides:
 * Aciidoctor Diagram with Graphviz integration so you can use plantuml and graphiz diagrams
 * Asciidoctor PDF (alpha)
 * Asciidoctor EPUB3 (alpha)
+* Asciidoctor Mathematical
+* Asciimath
 * Source highlighting using CodeRay or Pygments
 * Asciidoctor backends
 * Asciidoctor-fopub

--- a/tests/fixtures/sample-with-asciimath.adoc
+++ b/tests/fixtures/sample-with-asciimath.adoc
@@ -1,0 +1,23 @@
+= Precompiled Math
+:math: asciimath
+:imagesoutdir: generated_images
+:imagesdir: images
+:stem: asciimath
+
+Sample example, courtesy of link:https://github.com/aledomu[@aledomu], with inspiration from link:https://github.com/philwinder[@philwinder].
+
+== Equations in normal blocks
+
+[asciimath]
+++++
+k_(n+1) = n^2 + k_n^2 - k_(n-1)
+++++
+
+Some useful text!
+
+Formula for quadratic root:
+
+[asciimath]
+++++
+x = (-b +- sqrt(b^2 - 4ac)) / (2a)
+++++

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -125,6 +125,24 @@ teardown() {
   [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
 }
 
+@test "We can generate an HTML document with asciimath as backend" {
+  run docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
+      asciidoctor -D /documents/tmp -r asciimath \
+      /documents/fixtures/sample-with-asciimath.adoc
+
+  # Even when in ERROR with the module, asciidoctor return 0 because a document
+  # has been generated
+  [ "${status}" -eq 0 ]
+
+  echo "-- Output of command:"
+  echo "${output}"
+  echo "--"
+
+  [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
+}
+
 @test "We can generate a PDF document with asciidoctor-mathematical as backend" {
   run docker run -t --rm \
     -v "${BATS_TEST_DIRNAME}":/documents/ \
@@ -142,3 +160,6 @@ teardown() {
 
   [ "$(echo ${output} | grep -c -i error)" -eq 0 ]
 }
+
+# asciimath isn't tested with the PDF backend because it doesn't support stem blocks
+# without image rendering


### PR DESCRIPTION
Given that asciidoctor-mathematical is already bundled, I think if we are catering to STEM writers needs then it's a good idea to enable not-so-seasoned writers to use an easier (but equally powerful) format like ASCIIMath (I myself use it).

I also removed `README.md` and left `README.adoc` to avoid any confusion.