### PR TITLE
adding rugged to support git metadata preprocessor for asciidoctor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUP
 
 ARG asciidoctor_version=2.0.10
 ARG asciidoctor_confluence_version=0.0.2
-ARG asciidoctor_pdf_version=1.5.0.beta.4
+ARG asciidoctor_pdf_version=1.5.0.beta.5
 ARG asciidoctor_diagram_version=1.5.18
 ARG asciidoctor_epub3_version=1.5.0.alpha.9
 ARG asciidoctor_mathematical_version=0.3.1
@@ -17,6 +17,8 @@ ENV ASCIIDOCTOR_VERSION=${asciidoctor_version} \
   ASCIIDOCTOR_EPUB3_VERSION=${asciidoctor_epub3_version} \
   ASCIIDOCTOR_MATHEMATICAL_VERSION=${asciidoctor_mathematical_version} \
   ASCIIDOCTOR_REVEALJS_VERSION=${asciidoctor_revealjs_version}
+
+RUN apk update
 
 # Installing package required for the runtime of
 # any of the asciidoctor-* functionnalities

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN apk add --no-cache \
     inotify-tools \
     make \
     openjdk8-jre \
+    openssl \
+    openssl-dev \
     py2-pillow \
     py-setuptools \
     python2 \
@@ -45,6 +47,7 @@ RUN apk add --no-cache \
 # including asciidoctor itself
 RUN apk add --no-cache --virtual .rubymakedepends \
     build-base \
+    cmake \
     libxml2-dev \
     ruby-dev \
   && gem install --no-document \
@@ -63,6 +66,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     pygments.rb \
     rake \
     rouge \
+    rugged \
     slim \
     thread_safe \
     tilt \


### PR DESCRIPTION
this PR adds the dependencies needed to build `rugged` to support using the git metadata preprocessor extension from the extensions lab.

Built it for myself (heckj/docker-asciidoctor), and wanted to offer it upstream.