### PR TITLE
Add timezone support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apk add --no-cache \
     ruby-mathematical \
     ttf-liberation \
     ttf-dejavu \
+    tzdata \
     unzip \
     which
 

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -29,6 +29,10 @@ teardown() {
     | grep "Asciidoctor" | grep "${ASCIIDOCTOR_VERSION}"
 }
 
+@test "Timezone data is present in the image" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" test -f /usr/share/zoneinfo/posixrules
+}
+
 @test "asciidoctor-pdf is installed and in version ${ASCIIDOCTOR_PDF_VERSION}" {
   docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" asciidoctor-pdf -v \
     | grep "Asciidoctor PDF" | grep "${ASCIIDOCTOR_VERSION}" \


### PR DESCRIPTION
This PR adds support for timezone data in the image.

Closes #87.

A test case (white box) is added to check for the posix base file from the package `tzdata`.