### PR TITLE
Cleanup Makefile + verbose dockerhub trigger build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
 script:
 - make build
 - make test
-- make README.md
-
 
 before_deploy:
   # Set up git user name before generating README.md as part of deploy

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test:
 
 deploy:
 ifdef DOCKER_HUB_TRIGGER_URL
-	curl -H "Content-Type: application/json" \
+	curl --verbose --header "Content-Type: application/json" \
 		--data '{"source_type": "Branch", "source_name": "$(CURRENT_GIT_BRANCH)"}' \
 		-X POST $(DOCKER_HUB_TRIGGER_URL)
 else


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

This PR introduces the following changes:

- Do not run the `make README.md` step before deploy, to avoid triggering error messages around git username
- The `make deploy` step triggering a Dockerhub build is more verbose to help further errors