### PR TITLE
Allow Git tags to generate Docker tagged images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ services:
 
 env:
   global:
-    - CURRENT_GIT_BRANCH=$TRAVIS_BRANCH
+    - CURRENT_GIT_REF="${TRAVIS_BRANCH}" # Pass the tag, or target branch for a PR, or the branch
 
 script:
-- make build
-- make test
+  - make build
+  - make test
 
 before_deploy:
   # Set up git user name before generating README.md as part of deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,12 @@ before_deploy:
   - git config --local user.email "travis@travis-ci.org"
 
 deploy:
-- provider: script
-  script: make README.md deploy
-  # Do not deploy if Pull Request
-  # If a contributor want to deploy on its own DockerHub account:
-  # 1 - Enable Travis on the forked repository
-  # 2 - Set the environment variable DOCKERHUB_USERNAME in Travis Settings
-  on:
-    condition: $TRAVIS_PULL_REQUEST = false
+  - provider: script
+    script: make README.md deploy
+    # Do not deploy if Pull Request
+    # If a contributor want to deploy on its own DockerHub account:
+    # 1 - Enable Travis on the forked repository
+    # 2 - Set the environment variable DOCKERHUB_USERNAME in Travis Settings
+    on:
+      all_branches: true
+      condition: $TRAVIS_PULL_REQUEST = false

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 
 DOCKER_IMAGE_NAME ?= docker-asciidoctor
 DOCKERHUB_USERNAME ?= asciidoctor
-DOCKER_IMAGE_TEST_TAG ?= $(shell git rev-parse --short HEAD)
-DOCKER_IMAGE_NAME_TO_TEST ?= $(DOCKERHUB_USERNAME)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TEST_TAG)
+CURRENT_GIT_REF ?= $(shell git rev-parse --abbrev-ref HEAD) # Default to current branch
+DOCKER_IMAGE_TAG ?= $(shell echo $(CURRENT_GIT_REF) | sed 's/\//-/' )
+DOCKER_IMAGE_NAME_TO_TEST ?= $(DOCKERHUB_USERNAME)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 ASCIIDOCTOR_VERSION ?= 2.0.10
 ASCIIDOCTOR_CONFLUENCE_VERSION ?= 0.0.2
 ASCIIDOCTOR_PDF_VERSION ?= 1.5.0.rc.3
@@ -11,7 +12,6 @@ ASCIIDOCTOR_EPUB3_VERSION ?= 1.5.0.alpha.12
 ASCIIDOCTOR_MATHEMATICAL_VERSION ?= 0.3.1
 ASCIIDOCTOR_REVEALJS_VERSION ?= 3.1.0
 KRAMDOWN_ASCIIDOC_VERSION ?= 1.0.1
-CURRENT_GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 export DOCKER_IMAGE_NAME_TO_TEST \
   ASCIIDOCTOR_VERSION \
@@ -27,8 +27,8 @@ all: build test deploy
 
 build:
 	docker build \
-		-t $(DOCKER_IMAGE_NAME_TO_TEST) \
-		-f Dockerfile \
+		--tag="$(DOCKER_IMAGE_NAME_TO_TEST)" \
+		--file=Dockerfile \
 		$(CURDIR)/
 
 test:
@@ -36,8 +36,9 @@ test:
 
 deploy:
 ifdef DOCKER_HUB_TRIGGER_URL
+	
 	curl --verbose --header "Content-Type: application/json" \
-		--data '{"source_type": "Branch", "source_name": "$(CURRENT_GIT_BRANCH)"}' \
+		--data '{"source_type": "$(shell [ -n "${TRAVIS_TAG}" ] && echo Tag || echo Branch)", "source_name": "$(CURRENT_GIT_REF)"}' \
 		-X POST $(DOCKER_HUB_TRIGGER_URL)
 else
 	@echo 'Unable to deploy: Please define $$DOCKER_HUB_TRIGGER_URL'


### PR DESCRIPTION
This PR closes #54 .

It allows triggering a Travis CI build by creating a git tag or a github release,
that results in a a tagged Docker image.

Please note the following elements:

- The tag `latest` will be kept, containing the image built from the HEAD of the branch `master as it was before
- Git tag can happen on any branch, not only master
- The variable `TRAVIS_BRANCH` is used to pass the tag being built, as per https://docs.travis-ci.com/user/environment-variables#default-environment-variables . This documentation specifies that this variables contains the git tag which triggered the build (e.g. the same value as `$TRAVIS_TAG`), or the branch if it is "push-triggered" build (or the target branch if it is a PR).
- Tags and branch names with a `/` are supported: there is a search and replace rule which turns `/` to `-` for the resulting Docker tag, as the slash is not a valid character for a Docker tag.