### PR TITLE
Security: Improve deploy secrecy for Docker Hub Trigger URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,16 @@ test:
 	bats $(CURDIR)/tests/*.bats
 
 deploy:
-ifdef DOCKER_HUB_TRIGGER_URL
-
+ifdef DOCKERHUB_SOURCE_TOKEN
+ifdef DOCKERHUB_TRIGGER_TOKEN
 	curl --verbose --header "Content-Type: application/json" \
 		--data '{"source_type": "$(shell [ -n "${TRAVIS_TAG}" ] && echo Tag || echo Branch)", "source_name": "$(CURRENT_GIT_REF)"}' \
-		-X POST $(DOCKER_HUB_TRIGGER_URL)
+		-X POST https://hub.docker.com/api/build/v1/source/$(DOCKERHUB_SOURCE_TOKEN)/trigger/$(DOCKERHUB_TRIGGER_TOKEN)/call/
 else
-	@echo 'Unable to deploy: Please define $$DOCKER_HUB_TRIGGER_URL'
+	@echo 'Unable to deploy: Please define $$DOCKERHUB_TRIGGER_TOKEN'
+endif
+else
+	@echo 'Unable to deploy: Please define $$DOCKERHUB_SOURCE_TOKEN'
 endif
 
 clean:

--- a/README.adoc
+++ b/README.adoc
@@ -117,3 +117,15 @@ You can use bats directly to test the image, optional you can use a custome imag
 export DOCKER_IMAGE_NAME_TO_TEST=your-image-name
 bats tests/*.bats
 ----
+
+==== Deploy
+
+The goal of "deploying" is to have the Docker image available with the right "Docker tag" in the DockerHub.
+
+As a matter of trust and transparency for the end-users, the image is rebuilt by the DockerHub itself by triggering a build.
+This only works under the hypothesis of a minimalistic variation between the docker build in the CI, and the docker build by the Dockerhub.
+
+The following environment variables are required to be set: `DOCKERHUB_SOURCE_TOKEN` and `DOCKERHUB_TRIGGER_TOKEN`.
+Their values come from a DockerHub Trigger URL: `https://hub.docker.com/api/build/v1/source/${DOCKERHUB_SOURCE_TOKEN}/trigger/${DOCKERHUB_TRIGGER_TOKEN}/call/`.
+
+You might want to set these variables as "secret" values in your CI to avoid any leaking in the output (as `curl` output for instance).

--- a/README.md
+++ b/README.md
@@ -117,3 +117,15 @@ You can use bats directly to test the image, optional you can use a custome imag
 export DOCKER_IMAGE_NAME_TO_TEST=your-image-name
 bats tests/*.bats
 ```
+
+#### Deploy
+
+The goal of "deploying" is to have the Docker image available with the right "Docker tag" in the DockerHub.
+
+As a matter of trust and transparency for the end-users, the image is rebuilt by the DockerHub itself by triggering a build.
+This only works under the hypothesis of a minimalistic variation between the docker build in the CI, and the docker build by the Dockerhub.
+
+The following environment variables are required to be set: `DOCKERHUB_SOURCE_TOKEN` and `DOCKERHUB_TRIGGER_TOKEN`.
+Their values come from a DockerHub Trigger URL: `https://hub.docker.com/api/build/v1/source/${DOCKERHUB_SOURCE_TOKEN}/trigger/${DOCKERHUB_TRIGGER_TOKEN}/call/`.
+
+You might want to set these variables as "secret" values in your CI to avoid any leaking in the output (as `curl` output for instance).


### PR DESCRIPTION
This PR improves the "secrecy" for the deplyment to dockerhub.

Before this PR, there is an environment variable, `$DOCKER_HUB_TRIGGER_URL` containing the full trigger URL to start a new Dockerhub build from the github repository.

The URI part of this URL is printed unredacted within the Travis Job's logs (in the HTTP answer from the Dockerhub, as well on the "verbose" output of curl at least).

This PR split the URL in 2 tokens (one for the source, another for the trigger event) to ensure that nothing is leaked in the build output.

=> Please note that the impact of this leak is quite minore: worst case, someone could trigger a lot of build until the Docker Hub API rate limite blocks it.

Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>