### PR TITLE
Bump pandoc to 2.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 script:
   - make build
   - make test
+  - make README.md
 
 before_deploy:
   # Set up git user name before generating README.md as part of deploy
@@ -18,7 +19,7 @@ before_deploy:
 
 deploy:
   - provider: script
-    script: make README.md deploy
+    script: make deploy-README.md deploy
     # Do not deploy if Pull Request
     # If a contributor want to deploy on its own DockerHub account:
     # 1 - Enable Travis on the forked repository

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ASCIIDOCTOR_MATHEMATICAL_VERSION ?= 0.3.1
 ASCIIDOCTOR_REVEALJS_VERSION ?= 4.0.1
 KRAMDOWN_ASCIIDOC_VERSION ?= 1.0.1
 ASCIIDOCTOR_BIBTEX_VERSION ?= 0.7.1
+PANDOC_VERSION ?= 2.10.1
 
 export DOCKER_IMAGE_NAME_TO_TEST \
   ASCIIDOCTOR_VERSION \
@@ -58,18 +59,18 @@ clean:
 cache:
 	mkdir -p "$(CURDIR)/cache"
 
-cache/pandoc-2.2-linux.tar.gz: cache
-	curl -sSL -o "$(CURDIR)/cache/pandoc-2.2-linux.tar.gz" \
-	 	https://github.com/jgm/pandoc/releases/download/2.2/pandoc-2.2-linux.tar.gz
+cache/pandoc-$(PANDOC_VERSION)-linux.tar.gz: cache
+	curl -sSL -o "$(CURDIR)/cache/pandoc-$(PANDOC_VERSION)-linux.tar.gz" \
+	 	https://github.com/jgm/pandoc/releases/download/$(PANDOC_VERSION)/pandoc-$(PANDOC_VERSION)-linux-amd64.tar.gz
 
-cache/pandoc-2.2/bin/pandoc: cache/pandoc-2.2-linux.tar.gz
-	tar xzf "$(CURDIR)/cache/pandoc-2.2-linux.tar.gz" -C "$(CURDIR)/cache"
+cache/pandoc-$(PANDOC_VERSION)/bin/pandoc: cache/pandoc-$(PANDOC_VERSION)-linux.tar.gz
+	tar xzf "$(CURDIR)/cache/pandoc-$(PANDOC_VERSION)-linux.tar.gz" -C "$(CURDIR)/cache"
 
 # GitHub renders asciidoctor but DockerHub requires markdown.
 # This recipe creates README.md from README.adoc.
-README.md: build cache/pandoc-2.2/bin/pandoc
+README.md: build cache/pandoc-$(PANDOC_VERSION)/bin/pandoc
 	docker run --rm -t -v $(CURDIR):/documents --entrypoint bash $(DOCKER_IMAGE_NAME_TO_TEST) \
-		-c "asciidoctor -b docbook -a leveloffset=+1 -o - README.adoc | /documents/cache/pandoc-2.2/bin/pandoc  --atx-headers --wrap=preserve -t gfm -f docbook - > README.md"
+		-c "asciidoctor -b docbook -a leveloffset=+1 -o - README.adoc | /documents/cache/pandoc-$(PANDOC_VERSION)/bin/pandoc  --atx-headers --wrap=preserve -t gfm -f docbook - > README.md"
 	git add README.md && git commit -s -m "Updating README.md using 'make README.md command'" \
 		&& git push origin $(shell git rev-parse --abbrev-ref HEAD) || echo 'No changes to README.md'
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export DOCKER_IMAGE_NAME_TO_TEST \
   KRAMDOWN_ASCIIDOC_VERSION \
   ASCIIDOCTOR_BIBTEX_VERSION
 
-all: build test deploy
+all: build test README.md
 
 build:
 	docker build \
@@ -71,7 +71,9 @@ cache/pandoc-$(PANDOC_VERSION)/bin/pandoc: cache/pandoc-$(PANDOC_VERSION)-linux.
 README.md: build cache/pandoc-$(PANDOC_VERSION)/bin/pandoc
 	docker run --rm -t -v $(CURDIR):/documents --entrypoint bash $(DOCKER_IMAGE_NAME_TO_TEST) \
 		-c "asciidoctor -b docbook -a leveloffset=+1 -o - README.adoc | /documents/cache/pandoc-$(PANDOC_VERSION)/bin/pandoc  --atx-headers --wrap=preserve -t gfm -f docbook - > README.md"
+
+deploy-README.md: README.md
 	git add README.md && git commit -s -m "Updating README.md using 'make README.md command'" \
 		&& git push origin $(shell git rev-parse --abbrev-ref HEAD) || echo 'No changes to README.md'
 
-.PHONY: all build test deploy clean README.md
+.PHONY: all build test shell deploy clean README.md deploy-README.md

--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@
 
 This Docker image provides:
 
-  - [Asciidoctor](https://asciidoctor.org/) 2.0.10
+-   [Asciidoctor](https://asciidoctor.org/) 2.0.10
 
-  - [Asciidoctor Diagram](https://asciidoctor.org/docs/asciidoctor-diagram/) 2.0.1 with Graphviz integration (supports plantuml and graphiz diagrams)
+-   [Asciidoctor Diagram](https://asciidoctor.org/docs/asciidoctor-diagram/) 2.0.1 with Graphviz integration (supports plantuml and graphiz diagrams)
 
-  - [Asciidoctor PDF](https://asciidoctor.org/docs/asciidoctor-pdf/) 1.5.3
+-   [Asciidoctor PDF](https://asciidoctor.org/docs/asciidoctor-pdf/) 1.5.3
 
-  - [Asciidoctor EPUB3](https://asciidoctor.org/docs/asciidoctor-epub3/) 1.5.0.alpha.18
+-   [Asciidoctor EPUB3](https://asciidoctor.org/docs/asciidoctor-epub3/) 1.5.0.alpha.18
 
-  - [Asciidoctor Mathematical](https://github.com/asciidoctor/asciidoctor-mathematical) 0.3.1
+-   [Asciidoctor Mathematical](https://github.com/asciidoctor/asciidoctor-mathematical) 0.3.1
 
-  - [Asciidoctor reveal.js](https://asciidoctor.org/docs/asciidoctor-revealjs/) 4.0.1
+-   [Asciidoctor reveal.js](https://asciidoctor.org/docs/asciidoctor-revealjs/) 4.0.1
 
-  - [AsciiMath](https://rubygems.org/gems/asciimath)
+-   [AsciiMath](https://rubygems.org/gems/asciimath)
 
-  - Source highlighting using [Rouge](http://rouge.jneen.net) or [CodeRay](https://rubygems.org/gems/coderay) (Pygments not supported in the default Docker image as only Python 3 is available)
+-   Source highlighting using [Rouge](http://rouge.jneen.net) or [CodeRay](https://rubygems.org/gems/coderay) (Pygments not supported in the default Docker image as only Python 3 is available)
 
-  - [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
+-   [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
 
-  - [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.7.1
+-   [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.7.1
 
 This image uses Alpine Linux 3.12 as base image.
 
@@ -30,59 +30,45 @@ This image uses Alpine Linux 3.12 as base image.
 
 Just run:
 
-``` bash
-docker run -it -v <your directory>:/documents/ asciidoctor/docker-asciidoctor
-```
+    docker run -it -v <your directory>:/documents/ asciidoctor/docker-asciidoctor
 
 It will be directly mapped with */documents* of the container.
 
 Once started, you can use Asciidoctor commands to convert AsciiDoc files you created in the directory mentioned above. You can find several examples below.
 
-  - To run Asciidoctor on a basic AsciiDoc file:
-    
-    ``` bash
-    asciidoctor sample.adoc
-    asciidoctor-pdf sample.adoc
-    asciidoctor-epub3 sample.adoc
-    ```
+-   To run Asciidoctor on a basic AsciiDoc file:
 
-  - To run AsciiDoc on an AsciiDoc file that contains diagrams:
-    
-    ``` bash
-    asciidoctor -r asciidoctor-diagram sample-with-diagram.adoc
-    asciidoctor-pdf -r asciidoctor-diagram sample-with-diagram.adoc
-    asciidoctor-epub3 -r asciidoctor-diagram sample-with-diagram.adoc
-    ```
+        asciidoctor sample.adoc
+        asciidoctor-pdf sample.adoc
+        asciidoctor-epub3 sample.adoc
 
-  - To use Asciidoctor Confluence:
-    
-    ``` bash
-    asciidoctor-confluence --host HOSTNAME --spaceKey SPACEKEY --title TITLE --username USER --password PASSWORD sample.adoc
-    ```
+-   To run AsciiDoc on an AsciiDoc file that contains diagrams:
 
-  - To use Asciidoctor reveal.js with local downloaded reveal.js:
+        asciidoctor -r asciidoctor-diagram sample-with-diagram.adoc
+        asciidoctor-pdf -r asciidoctor-diagram sample-with-diagram.adoc
+        asciidoctor-epub3 -r asciidoctor-diagram sample-with-diagram.adoc
 
-<!-- end list -->
+-   To use Asciidoctor Confluence:
 
-``` bash
-asciidoctor-revealjs sample-slides.adoc
-asciidoctor-revealjs -r asciidoctor-diagram sample-slides.adoc
-```
+        asciidoctor-confluence --host HOSTNAME --spaceKey SPACEKEY --title TITLE --username USER --password PASSWORD sample.adoc
 
-  - To use Asciidoctor reveal.js with online reveal.js:
+-   To use Asciidoctor reveal.js with local downloaded reveal.js:
 
-<!-- end list -->
+<!-- -->
 
-``` bash
-asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 sample-slides.adoc
-asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 -r asciidoctor-diagram sample-slides.adoc
-```
+    asciidoctor-revealjs sample-slides.adoc
+    asciidoctor-revealjs -r asciidoctor-diagram sample-slides.adoc
 
-  - Batch mode. You can use it in a "batch" mode
-    
-    ``` bash
-    docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf index.adoc
-    ```
+-   To use Asciidoctor reveal.js with online reveal.js:
+
+<!-- -->
+
+    asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 sample-slides.adoc
+    asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 -r asciidoctor-diagram sample-slides.adoc
+
+-   Batch mode. You can use it in a "batch" mode
+
+        docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf index.adoc
 
 ## How to contribute / do it yourself ?
 
@@ -90,33 +76,29 @@ asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/revea
 
 You need the following tools:
 
-  - A bash compliant command line
+-   A bash compliant command line
 
-  - [GNU make](http://man7.org/linux/man-pages/man1/make.1.html)
+-   [GNU make](http://man7.org/linux/man-pages/man1/make.1.html)
 
-  - [bats](https://github.com/sstephenson/bats) installed and in your bash PATH
+-   [bats](https://github.com/sstephenson/bats) installed and in your bash PATH
 
-  - Docker installed and in your path
+-   Docker installed and in your path
 
 ### How to build and test ?
 
-  - "bats" is used as a test suite runner. Since the ability to build is one way of testing, it is included.
+-   "bats" is used as a test suite runner. Since the ability to build is one way of testing, it is included.
 
-  - You just have to run the bats test suite, from the repository root:
-    
-    ``` bash
-    make test
-    ```
+-   You just have to run the bats test suite, from the repository root:
+
+        make test
 
 #### Include test in your build pipeline or test manually
 
 You can use bats directly to test the image, optional you can use a custome image name:
 
-``` bash
-# If you want to use a custom name for the image, OPTIONAL
-export DOCKER_IMAGE_NAME_TO_TEST=your-image-name
-bats tests/*.bats
-```
+    # If you want to use a custom name for the image, OPTIONAL
+    export DOCKER_IMAGE_NAME_TO_TEST=your-image-name
+    bats tests/*.bats
 
 #### Deploy
 


### PR DESCRIPTION
This PR introduces a few minor changes:

- Bump pandoc to 2.10.1
- Update the file `README.md` to validate pandoc version's bump
- Introduce a new make goal: `make deploy-README.md` (wip)

Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>