### PR TITLE
Remove Kindlegen gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,6 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     coderay \
     epubcheck-ruby:4.2.2.0 \
     haml \
-    kindlegen:3.0.5 \
     "kramdown-asciidoc:${KRAMDOWN_ASCIIDOC_VERSION}" \
     rouge \
     slim \


### PR DESCRIPTION
As noticed by @slonopotamus in https://github.com/tdtds/kindlegen/issues/42 and https://github.com/asciidoctor/asciidoctor-epub3/issues/363, the binaries for `kindlegen` are no longer available.

As it breaks the build (the gem installation of the ruby Gem `kindlegen` fails when downloading this binary),
this PR remove the dependency to the `kindlegen` Ruby Gem.

Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>