### PR TITLE
docs: layout and terms

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,9 +32,10 @@ Just run:
 docker run -it -v <your directory>:/documents/ asciidoctor/docker-asciidoctor
 ----
 
-It will be directly mapped with [path]_/documents_ of the container.
+Docker maps your directory with [path]_/documents_ directory in the container.
 
-Once started, you can use Asciidoctor commands to convert AsciiDoc files you created in the directory mentioned above. You can find several examples below.
+After you start the container, you can use Asciidoctor commands to convert AsciiDoc files that you created in the directory mentioned above.
+You can find several examples below.
 
 * To run Asciidoctor on a basic AsciiDoc file:
 +
@@ -62,7 +63,7 @@ asciidoctor-confluence --host HOSTNAME --spaceKey SPACEKEY --title TITLE --usern
 ----
 
 * To use Asciidoctor reveal.js with local downloaded reveal.js:
-
++
 [source,bash]
 ----
 asciidoctor-revealjs sample-slides.adoc
@@ -70,22 +71,21 @@ asciidoctor-revealjs -r asciidoctor-diagram sample-slides.adoc
 ----
 
 * To use Asciidoctor reveal.js with online reveal.js:
-
++
 [source,bash]
 ----
 asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 sample-slides.adoc
 asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 -r asciidoctor-diagram sample-slides.adoc
 ----
 
-
-* Batch mode. You can use it in a "batch" mode
+* To convert files in batch:
 +
 [source, bash]
 ----
 docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf index.adoc
 ----
 
-== How to contribute / do it yourself ?
+== How to contribute / do it yourself?
 
 === Requirements
 
@@ -93,14 +93,14 @@ You need the following tools:
 
 * A bash compliant command line
 * link:http://man7.org/linux/man-pages/man1/make.1.html[GNU make]
-* link:https://github.com/sstephenson/bats[bats] installed and in your bash PATH
+* link:https://github.com/sstephenson/bats[Bats] installed and in your bash PATH
 * Docker installed and in your path
 
-=== How to build and test ?
+=== How to build and test?
 
-* "bats" is used as a test suite runner. Since the ability to build is one way of testing, it is included.
+* Bats is used as a test suite runner. Since the ability to build is one way of testing, it is included.
 
-* You just have to run the bats test suite, from the repository root:
+* You just have to run the Bats test suite, from the repository root:
 +
 [source,bash]
 ----
@@ -109,7 +109,8 @@ make test
 
 ==== Include test in your build pipeline or test manually
 
-You can use bats directly to test the image, optional you can use a custome image name:
+You can use Bats directly to test the image.
+Optionally, you can specify a custom image name:
 
 [source,bash]
 ----
@@ -120,12 +121,12 @@ bats tests/*.bats
 
 ==== Deploy
 
-The goal of "deploying" is to have the Docker image available with the right "Docker tag" in the DockerHub.
+The goal for deploying is to make the Docker image available with the correct Docker tag in Docker Hub.
 
-As a matter of trust and transparency for the end-users, the image is rebuilt by the DockerHub itself by triggering a build.
-This only works under the hypothesis of a minimalistic variation between the docker build in the CI, and the docker build by the Dockerhub.
+As a matter of trust and transparency for the end-users, the image is rebuilt by Docker Hub itself by triggering a build.
+This only works under the hypothesis of a minimalistic variation between the Docker build in the CI, and the Docker build by Docker Hub.
 
-The following environment variables are required to be set: `DOCKERHUB_SOURCE_TOKEN` and `DOCKERHUB_TRIGGER_TOKEN`.
-Their values come from a DockerHub Trigger URL: `https://hub.docker.com/api/build/v1/source/${DOCKERHUB_SOURCE_TOKEN}/trigger/${DOCKERHUB_TRIGGER_TOKEN}/call/`.
+Deploying the image requires setting the following environment variables: `DOCKERHUB_SOURCE_TOKEN` and `DOCKERHUB_TRIGGER_TOKEN`.
+Their values come from a Docker Hub trigger URL: `https://hub.docker.com/api/build/v1/source/${DOCKERHUB_SOURCE_TOKEN}/trigger/${DOCKERHUB_TRIGGER_TOKEN}/call/`.
 
-You might want to set these variables as "secret" values in your CI to avoid any leaking in the output (as `curl` output for instance).
+You might want to set these variables as secret values in your CI to avoid any leaking in the output (as `curl` output for instance).

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Just run:
 
     docker run -it -v <your directory>:/documents/ asciidoctor/docker-asciidoctor
 
-It will be directly mapped with */documents* of the container.
+Docker maps your directory with */documents* directory in the container.
 
-Once started, you can use Asciidoctor commands to convert AsciiDoc files you created in the directory mentioned above. You can find several examples below.
+After you start the container, you can use Asciidoctor commands to convert AsciiDoc files that you created in the directory mentioned above.
+You can find several examples below.
 
 -   To run Asciidoctor on a basic AsciiDoc file:
 
@@ -54,23 +55,19 @@ Once started, you can use Asciidoctor commands to convert AsciiDoc files you cre
 
 -   To use Asciidoctor reveal.js with local downloaded reveal.js:
 
-<!-- -->
-
-    asciidoctor-revealjs sample-slides.adoc
-    asciidoctor-revealjs -r asciidoctor-diagram sample-slides.adoc
+        asciidoctor-revealjs sample-slides.adoc
+        asciidoctor-revealjs -r asciidoctor-diagram sample-slides.adoc
 
 -   To use Asciidoctor reveal.js with online reveal.js:
 
-<!-- -->
+        asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 sample-slides.adoc
+        asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 -r asciidoctor-diagram sample-slides.adoc
 
-    asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 sample-slides.adoc
-    asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2 -r asciidoctor-diagram sample-slides.adoc
-
--   Batch mode. You can use it in a "batch" mode
+-   To convert files in batch:
 
         docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf index.adoc
 
-## How to contribute / do it yourself ?
+## How to contribute / do it yourself?
 
 ### Requirements
 
@@ -80,21 +77,22 @@ You need the following tools:
 
 -   [GNU make](http://man7.org/linux/man-pages/man1/make.1.html)
 
--   [bats](https://github.com/sstephenson/bats) installed and in your bash PATH
+-   [Bats](https://github.com/sstephenson/bats) installed and in your bash PATH
 
 -   Docker installed and in your path
 
-### How to build and test ?
+### How to build and test?
 
--   "bats" is used as a test suite runner. Since the ability to build is one way of testing, it is included.
+-   Bats is used as a test suite runner. Since the ability to build is one way of testing, it is included.
 
--   You just have to run the bats test suite, from the repository root:
+-   You just have to run the Bats test suite, from the repository root:
 
         make test
 
 #### Include test in your build pipeline or test manually
 
-You can use bats directly to test the image, optional you can use a custome image name:
+You can use Bats directly to test the image.
+Optionally, you can specify a custom image name:
 
     # If you want to use a custom name for the image, OPTIONAL
     export DOCKER_IMAGE_NAME_TO_TEST=your-image-name
@@ -102,12 +100,12 @@ You can use bats directly to test the image, optional you can use a custome imag
 
 #### Deploy
 
-The goal of "deploying" is to have the Docker image available with the right "Docker tag" in the DockerHub.
+The goal for deploying is to make the Docker image available with the correct Docker tag in Docker Hub.
 
-As a matter of trust and transparency for the end-users, the image is rebuilt by the DockerHub itself by triggering a build.
-This only works under the hypothesis of a minimalistic variation between the docker build in the CI, and the docker build by the Dockerhub.
+As a matter of trust and transparency for the end-users, the image is rebuilt by Docker Hub itself by triggering a build.
+This only works under the hypothesis of a minimalistic variation between the Docker build in the CI, and the Docker build by Docker Hub.
 
-The following environment variables are required to be set: `DOCKERHUB_SOURCE_TOKEN` and `DOCKERHUB_TRIGGER_TOKEN`.
-Their values come from a DockerHub Trigger URL: `https://hub.docker.com/api/build/v1/source/${DOCKERHUB_SOURCE_TOKEN}/trigger/${DOCKERHUB_TRIGGER_TOKEN}/call/`.
+Deploying the image requires setting the following environment variables: `DOCKERHUB_SOURCE_TOKEN` and `DOCKERHUB_TRIGGER_TOKEN`.
+Their values come from a Docker Hub trigger URL: `https://hub.docker.com/api/build/v1/source/${DOCKERHUB_SOURCE_TOKEN}/trigger/${DOCKERHUB_TRIGGER_TOKEN}/call/`.
 
-You might want to set these variables as "secret" values in your CI to avoid any leaking in the output (as `curl` output for instance).
+You might want to set these variables as secret values in your CI to avoid any leaking in the output (as `curl` output for instance).


### PR DESCRIPTION
- Make sure the code block examples are
  part of the preceding bullet.

- Use parallel lingo for the para lead
  ins to the code blocks.

- The website for Bats seems to use an
  uppercase B.

- The website for Docker Hub seems to use
  two words.