### PR TITLE
Add Pygments syntax highlighting via pygments.rb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     epubcheck-ruby:4.2.4.0 \
     haml \
     "kramdown-asciidoc:${KRAMDOWN_ASCIIDOC_VERSION}" \
+    pygments.rb \
     rouge \
     slim \
     thread_safe \

--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ This Docker image provides:
 * https://github.com/asciidoctor/asciidoctor-mathematical[Asciidoctor Mathematical] 0.3.4
 * https://asciidoctor.org/docs/asciidoctor-revealjs/[Asciidoctor reveal.js] 4.0.1
 * https://rubygems.org/gems/asciimath[AsciiMath]
-* Source highlighting using http://rouge.jneen.net[Rouge] or https://rubygems.org/gems/coderay[CodeRay] (Pygments not supported in the default Docker image as only Python 3 is available)
+* Source highlighting using http://rouge.jneen.net[Rouge], https://rubygems.org/gems/coderay[CodeRay] or https://pygments.org/[Pygments]
 * https://github.com/asciidoctor/asciidoctor-confluence[Asciidoctor Confluence] 0.0.2
 * https://github.com/asciidoctor/asciidoctor-bibtex[Asciidoctor Bibtex] 0.8.0
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This Docker image provides:
 
 -   [AsciiMath](https://rubygems.org/gems/asciimath)
 
--   Source highlighting using [Rouge](http://rouge.jneen.net) or [CodeRay](https://rubygems.org/gems/coderay) (Pygments not supported in the default Docker image as only Python 3 is available)
+-   Source highlighting using [Rouge](http://rouge.jneen.net), [CodeRay](https://rubygems.org/gems/coderay) or [Pygments](https://pygments.org/)
 
 -   [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
 

--- a/tests/fixtures/samples-syntax-highlight/sample-syntax-pygments.adoc
+++ b/tests/fixtures/samples-syntax-highlight/sample-syntax-pygments.adoc
@@ -1,0 +1,4 @@
+
+:source-highlighter: pygments
+
+include::includes/syntax-template.adoc[]


### PR DESCRIPTION
Modern pygments.rb [uses Python 3](https://github.com/pygments/pygments.rb/commit/88fac6be1d22c22bc1a54c35418b345b370c520b), so the old reason for its exclusion from docker image is no longer valid.