### PR TITLE
Bump base image to Alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 DOCKER_IMAGE_NAME ?= docker-asciidoctor
 DOCKERHUB_USERNAME ?= asciidoctor
+export DOCKER_BUILDKIT=1
 CURRENT_GIT_REF ?= $(shell git rev-parse --abbrev-ref HEAD) # Default to current branch
 DOCKER_IMAGE_TAG ?= $(shell echo $(CURRENT_GIT_REF) | sed 's/\//-/' )
 DOCKER_IMAGE_NAME_TO_TEST ?= $(DOCKERHUB_USERNAME)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ This Docker image provides:
 * https://github.com/asciidoctor/asciidoctor-confluence[Asciidoctor Confluence] 0.0.2
 * https://github.com/asciidoctor/asciidoctor-bibtex[Asciidoctor Bibtex] 0.8.0
 
-This image uses Alpine Linux 3.12 as base image.
+This image uses Alpine Linux 3.13 as base image.
 
 == How to use it
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This Docker image provides:
 
 -   [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.8.0
 
-This image uses Alpine Linux 3.12 as base image.
+This image uses Alpine Linux 3.13 as base image.
 
 ## How to use it
 


### PR DESCRIPTION
This PR introduces 2 changes:

- Bump the base image to Alpine 3.13 (documentation included)
- Enable Buildkit to improve build's speed and caching