### PR TITLE
Fix the tag deploy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
         run: |
           git config --local user.name "${GITHUB_ACTOR}"
           git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      - name: Set up env vars
-        run: echo "CURRENT_GIT_REF='$(echo ${GITHUB_REF} | awk 'BEGIN { FS = "/" } ; { print $3 }')'" >> "${GITHUB_ENV}" # Pass the tag, or target branch for a PR, or the branch
       - name: Build
         run: |
           make build


### PR DESCRIPTION
The `Makefile` is now autonomous to determine the git tag and the ref,
making this process independant from the CI tool.

It utilizes the command line `git` to parse the current "ref".

The algorithm is the following:

- If the current git ref points to a tag, then the variables `GIT_TAG`
and `GIT_REF` are set to this tag's value.
- Otherwise the variable `GIT_TAG` is undefined, and the variable
`GIT_REF` is set to the current's branch

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>