### PR TITLE
✨ Add Release Drafter to auto-generate changelog for GitHub releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,26 @@
+# Please note that emoji usages follows this guide: https://gitmoji.dev/
+---
+categories:
+  - title: '✨ New Features/ Enhancements'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'feat'
+      - 'improvement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+      - 'doc'
+      - 'docs'
+  - title: '💚 Chores'
+    labels:
+      - 'chores'
+      - 'chore'
+exclude-labels:
+  - 'skip-changelog'
+...

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+---
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          # This token is generated automatically by default in GitHub Actions: no need to create it manually
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+...


### PR DESCRIPTION
Considering the pattern followed by this project:

* Pull Requests (PR) based changes
* A given PR is only merged if tests are passing
* When a PR is merged to the principal branch, then it triggers a deployment of the `:latest` tag on the DockerHub
* When a new git tag is created, then a deployment with the `:<tag>` is triggered on the DockerHub
* For each git tag there is corresponding GitHub release with a changelog of the changes since the last version

Then it makes the project a great candidate for using the project [Release Drafter](https://github.com/release-drafter/release-drafter) to auot-generate the changelog.

This PR introduces the usage of Release Drafter for this case.