### PR TITLE
Update Asciidoctor reveal.js version to 4.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG asciidoctor_pdf_version=1.5.4
 ARG asciidoctor_diagram_version=2.1.0
 ARG asciidoctor_epub3_version=1.5.0.alpha.19
 ARG asciidoctor_mathematical_version=0.3.5
-ARG asciidoctor_revealjs_version=4.0.1
+ARG asciidoctor_revealjs_version=4.1.0
 ARG kramdown_asciidoc_version=1.0.1
 ARG asciidoctor_bibtex_version=0.8.0
 

--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ This Docker image provides:
 * https://asciidoctor.org/docs/asciidoctor-pdf/[Asciidoctor PDF] 1.5.4
 * https://asciidoctor.org/docs/asciidoctor-epub3/[Asciidoctor EPUB3] 1.5.0.alpha.19
 * https://github.com/asciidoctor/asciidoctor-mathematical[Asciidoctor Mathematical] 0.3.5
-* https://asciidoctor.org/docs/asciidoctor-revealjs/[Asciidoctor reveal.js] 4.0.1
+* https://docs.asciidoctor.org/reveal.js-converter/latest/[Asciidoctor reveal.js] 4.1.0
 * https://rubygems.org/gems/asciimath[AsciiMath]
 * Source highlighting using http://rouge.jneen.net[Rouge], https://rubygems.org/gems/coderay[CodeRay] or https://pygments.org/[Pygments]
 * https://github.com/asciidoctor/asciidoctor-confluence[Asciidoctor Confluence] 0.0.2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Docker image provides:
 
 -   [Asciidoctor Mathematical](https://github.com/asciidoctor/asciidoctor-mathematical) 0.3.5
 
--   [Asciidoctor reveal.js](https://asciidoctor.org/docs/asciidoctor-revealjs/) 4.0.1
+-   [Asciidoctor reveal.js](https://docs.asciidoctor.org/reveal.js-converter/latest/) 4.1.0
 
 -   [AsciiMath](https://rubygems.org/gems/asciimath)
 


### PR DESCRIPTION
Release note: https://github.com/asciidoctor/asciidoctor-reveal.js/releases/tag/v4.1.0