### PR TITLE
Improve workflow trigger for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
-on: [ push, pull_request ]
+on:
+  ## Events from external actor, or from code pushed (includes tags pushed)
+  push:
+  pull_request:
+  ## Events from the GitHub UI (as when publishing a release)
+  # When a release is "released" (draft or released published, no pre-release) - https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#release
+  release:
+    types: [released]
+  # When a tag or branch is created in the GitHub UI
+  create:
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR aims to close #185 by adding new workflow trigger events to catch when a release is published.

Before #180, (tags <= `1.3.0`), tags were created on a machine and pushed. The workflow was triggered due to this "push" event.

But since then, the tag is created by publishing a draft release in the GitHub UI.

This PR also consider the addition case where a tag could be created through an API call to GitHub and/or usage of the `gh` CLI, by adding the `create:` event.