### PR TITLE
Add stage with minimal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,23 @@ ENV ASCIIDOCTOR_VERSION=${asciidoctor_version} \
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Minimal image with asciidoctor
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+FROM base AS main-minimal
+RUN echo "assemble minimal main image" # keep here to help --cache-from along
+
+LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
+
+RUN apk add --no-cache \
+    ruby
+
+RUN gem install --no-document \
+    "asciidoctor:${ASCIIDOCTOR_VERSION}" \
+    "asciidoctor-pdf:${ASCIIDOCTOR_PDF_VERSION}"
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Haskell build for: erd
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -50,13 +67,13 @@ RUN cabal v2-update \
 # Final image
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-FROM base AS main
-RUN echo "building main image" # keep here to help --cache-from along
+FROM main-minimal AS main
+RUN echo "assemble comprehensive main image" # keep here to help --cache-from along
 
 LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 
-# Installing package required for the runtime of
-# any of the asciidoctor-* functionnalities
+# Installing packagse required for the runtime of
+# any of the asciidoctor-* functionalities
 RUN apk add --no-cache \
     bash \
     curl \
@@ -71,7 +88,6 @@ RUN apk add --no-cache \
     python3 \
     py3-pillow \
     py3-setuptools \
-    ruby \
     ruby-bigdecimal \
     ruby-mathematical \
     ruby-rake \
@@ -81,20 +97,17 @@ RUN apk add --no-cache \
     unzip \
     which
 
-# Installing Ruby Gems needed in the image
-# including asciidoctor itself
+# Installing Ruby Gems for additional functionality
 RUN apk add --no-cache --virtual .rubymakedepends \
     build-base \
     libxml2-dev \
     ruby-dev \
   && gem install --no-document \
-    "asciidoctor:${ASCIIDOCTOR_VERSION}" \
     "asciidoctor-confluence:${ASCIIDOCTOR_CONFLUENCE_VERSION}" \
     "asciidoctor-diagram:${ASCIIDOCTOR_DIAGRAM_VERSION}" \
     "asciidoctor-epub3:${ASCIIDOCTOR_EPUB3_VERSION}" \
     "asciidoctor-mathematical:${ASCIIDOCTOR_MATHEMATICAL_VERSION}" \
     asciimath \
-    "asciidoctor-pdf:${ASCIIDOCTOR_PDF_VERSION}" \
     "asciidoctor-revealjs:${ASCIIDOCTOR_REVEALJS_VERSION}" \
     coderay \
     epubcheck-ruby:4.2.4.0 \
@@ -109,8 +122,8 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     "asciidoctor-bibtex:${ASCIIDOCTOR_BIBTEX_VERSION}" \
   && apk del -r --no-cache .rubymakedepends
 
-# Installing Python dependencies for additional
-# functionnalities as diagrams or syntax highligthing
+# Installing Python dependencies for additional functionality
+# such as diagrams (blockdiag) or syntax highligthing
 RUN apk add --no-cache --virtual .pythonmakedepends \
     build-base \
     python3-dev \

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ all: build test README.md
 
 build:
 	docker build \
+		--target main-minimal \
+		--tag="$(DOCKER_IMAGE_NAME_TO_TEST)-minimal" \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--cache-from="$(DOCKER_IMAGE_NAME_TO_TEST)-minimal" \
+		--file=Dockerfile \
+		$(CURDIR)/
+	docker build \
 		--target build-haskell \
 		--tag="$(DOCKER_IMAGE_NAME_TO_TEST)-build-haskell" \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
@@ -46,6 +53,7 @@ build:
 		--target main \
 		--tag="$(DOCKER_IMAGE_NAME_TO_TEST)" \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--cache-from="$(DOCKER_IMAGE_NAME_TO_TEST)-minimal" \
 		--cache-from="$(DOCKER_IMAGE_NAME_TO_TEST)-build-haskell" \
 		--cache-from="$(DOCKER_IMAGE_NAME_TO_TEST)" \
 		--file=Dockerfile \


### PR DESCRIPTION
For simple use cases, a smaller image than the full ~450MB can suffice.

This MR adds a separate build stage with a minimal image of ~40MB that contains the bare minimum to run asciidoctor(-pdf); everything else would have to be added usage-site.

```bash
$ make build
<snip>
$ docker run --rm asciidoctor/docker-asciidoctor:multi-stage-build-minimal sh -c "asciidoctor --version && asciidoctor-pdf --version"
Asciidoctor 2.0.12 [https://asciidoctor.org]
Runtime Environment (ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux-musl]) (lc:UTF-8 fs:UTF-8 in:UTF-8 ex:UTF-8)
Asciidoctor PDF 1.5.4 using Asciidoctor 2.0.12 [https://asciidoctor.org]
Runtime Environment (ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux-musl]) (lc:UTF-8 fs:UTF-8 in:UTF-8 ex:UTF-8)
```