### PR TITLE
chore: enable automatic update for asciidoctor components

### DIFF
--- a/updatecli/updatecli.d/asciidoctor-bibtex.yml
+++ b/updatecli/updatecli.d/asciidoctor-bibtex.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-Bibtex version"
+sources:
+  getAsciidoctorBibtexVersion:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Bibtex version"
+    spec:
+      owner: "asciidoctor"
+      repository: "asciidoctor-bibtex"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_bibtex_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_bibtex_version"
+targets:
+  updateHarnessEnvAsciidoctorBibtexVersion:
+    name: "Update the key ASCIIDOCTOR_BIBTEX_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorBibtexVersion
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ASCIIDOCTOR_BIBTEX_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG asciidoctor_bibtex_version in the Dockerfile"
+    sourceID: getAsciidoctorBibtexVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_bibtex_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/asciidoctor-diagram.yml
+++ b/updatecli/updatecli.d/asciidoctor-diagram.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-Diagram version"
+sources:
+  getAsciidoctorDiagramVersion:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Diagram version"
+    spec:
+      owner: "asciidoctor"
+      repository: "asciidoctor-diagram"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_diagram_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_diagram_version"
+targets:
+  updateHarnessEnvAsciidoctorDiagramVersion:
+    name: "Update the key ASCIIDOCTOR_DIAGRAM_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorDiagramVersion
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ASCIIDOCTOR_DIAGRAM_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG asciidoctor_diagram_version in the Dockerfile"
+    sourceID: getAsciidoctorDiagramVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_diagram_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/asciidoctor-epub3.yml
+++ b/updatecli/updatecli.d/asciidoctor-epub3.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-Epub3 version"
+sources:
+  getAsciidoctorEpub3Version:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Epub3 version"
+    spec:
+      owner: "asciidoctor"
+      repository: "asciidoctor-epub3"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_epub3_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_epub3_version"
+targets:
+  updateHarnessEnvAsciidoctorEpub3Version:
+    name: "Update the key ASCIIDOCTOR_EPUB3_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorEpub3Version
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ASCIIDOCTOR_EPUB3_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG asciidoctor_epub3_version in the Dockerfile"
+    sourceID: getAsciidoctorEpub3Version
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_epub3_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/asciidoctor-fb2.yml
+++ b/updatecli/updatecli.d/asciidoctor-fb2.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-Fb2 version"
+sources:
+  getAsciidoctorFb2Version:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Fb2 version"
+    spec:
+      owner: "asciidoctor"
+      repository: "asciidoctor-fb2"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_fb2_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_fb2_version"
+targets:
+  updateHarnessEnvAsciidoctorFb2Version:
+    name: "Update the key ASCIIDOCTOR_FB2_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorFb2Version
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ASCIIDOCTOR_FB2_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG asciidoctor_fb2_version in the Dockerfile"
+    sourceID: getAsciidoctorFb2Version
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_fb2_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/asciidoctor-kramdown.yml
+++ b/updatecli/updatecli.d/asciidoctor-kramdown.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-Kramdown version"
+sources:
+  getAsciidoctorKramdownVersion:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Kramdown version"
+    spec:
+      owner: "asciidoctor"
+      repository: "kramdown-asciidoc"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is kramdown_asciidoc_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "kramdown_asciidoc_version"
+targets:
+  updateHarnessEnvAsciidoctorKramdownVersion:
+    name: "Update the key KRAMDOWN_ASCIIDOC_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorKramdownVersion
+    spec:
+      file: "tests/env_vars.yml"
+      key: "KRAMDOWN_ASCIIDOC_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG kramdown_asciidoc_version in the Dockerfile"
+    sourceID: getAsciidoctorKramdownVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "kramdown_asciidoc_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/asciidoctor-mathematical.yml
+++ b/updatecli/updatecli.d/asciidoctor-mathematical.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-Mathematical version"
+sources:
+  getAsciidoctorMathematicalVersion:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Mathematical version"
+    spec:
+      owner: "asciidoctor"
+      repository: "asciidoctor-mathematical"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_mathematical_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_mathematical_version"
+targets:
+  updateHarnessEnvAsciidoctorMathematicalVersion:
+    name: "Update the key ASCIIDOCTOR_MATHEMATICAL_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorMathematicalVersion
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ASCIIDOCTOR_MATHEMATICAL_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG asciidoctor_mathematical_version in the Dockerfile"
+    sourceID: getAsciidoctorMathematicalVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_mathematical_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/asciidoctor-pdf.yml
+++ b/updatecli/updatecli.d/asciidoctor-pdf.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-PDF version"
+sources:
+  getAsciidoctorPDFVersion:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-PDF version"
+    spec:
+      owner: "asciidoctor"
+      repository: "asciidoctor-pdf"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_pdf_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_pdf_version"
+targets:
+  updateHarnessEnvAsciidoctorPDFVersion:
+    name: "Update the key ASCIIDOCTOR_PDF_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorPDFVersion
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ASCIIDOCTOR_PDF_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG asciidoctor_pdf_version in the Dockerfile"
+    sourceID: getAsciidoctorPDFVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_pdf_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/asciidoctor-revealjs.yml
+++ b/updatecli/updatecli.d/asciidoctor-revealjs.yml
@@ -1,0 +1,59 @@
+---
+title: "Bump Asciidoctor-Revealjs version"
+sources:
+  getAsciidoctorRevealjsVersion:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Revealjs version"
+    spec:
+      owner: "asciidoctor"
+      repository: "asciidoctor-reveal.js"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+conditions:
+  testDockerfileArgGoVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_revealjs_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_revealjs_version"
+targets:
+  updateHarnessEnvAsciidoctorRevealjsVersion:
+    name: "Update the key ASCIIDOCTOR_REVEALJS_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAsciidoctorRevealjsVersion
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ASCIIDOCTOR_REVEALJS_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateDockerfileArgGoVersion:
+    name: "Update the value of ARG asciidoctor_revealjs_version in the Dockerfile"
+    sourceID: getAsciidoctorRevealjsVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_revealjs_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"


### PR DESCRIPTION
Following the work done in #193 , all the component with a fixed version defined as an `ARG` instruction are now automatically updated by updatecli.