### PR TITLE
Add CJK font to support Chinese/Japanese/Korean UML diagram

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,8 @@ RUN apk add --no-cache \
     ttf-dejavu \
     tzdata \
     unzip \
-    which
+    which \
+    font-noto-cjk
 
 # Installing Ruby Gems for additional functionality
 RUN apk add --no-cache --virtual .rubymakedepends \

--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -152,6 +152,10 @@ teardown() {
   docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" apk info font-bakoma-ttf
 }
 
+@test "Noto CJK Fonts are installed to render correctly the PlantUML diagram from asciidoctor-diagram" {
+  docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" apk info font-noto-cjk
+}
+
 @test "DejaVu Fonts are installed to get corretly rendered PlantUML-Graphs" {
   docker run -t --rm "${DOCKER_IMAGE_NAME_TO_TEST}" fc-list "DejaVu Sans"
 }


### PR DESCRIPTION
To use Chinese/Japanese/Korean in a UML diagram, we need to add a font.

For example, compile the following asciidoctor file including UML diagram in Japanese
```
= This file is a sample file including Japanese in UML

== Sample UML
[plantuml]
----
@startuml

人間A --> 人間B : メッセージの送信
人間B --> 人間A : 返信

@enduml
----
```

Without adding the font, the output will be garbled as shown below.
![without_adding_font](https://user-images.githubusercontent.com/23313273/117149712-6b5ed500-adf2-11eb-8174-5e635b8d3efa.png)

If the font is added, the output will be normal as shown below.
![adding_font](https://user-images.githubusercontent.com/23313273/117149732-7154b600-adf2-11eb-9468-b5aac4be9869.png)

This is a logs to indicate this.
```
mrcsce@pop-os:~/programming/asciidoctor-japanese$ cat sample_including_japanese.adoc 
= This file is a sample file including Japanese in UML

== Sample UML
[plantuml]
----
@startuml

人間A --> 人間B : メッセージの送信
人間B --> 人間A : 返信

@enduml
----
mrcsce@pop-os:~/programming/asciidoctor-japanese$ sudo docker run -it -v /home/mrcsce/programming/asciidoctor-japanese:/documents/ asciidoctor/docker-asciidoctor
bash-5.1# ls
sample_including_japanese.adoc
bash-5.1# asciidoctor -r asciidoctor-diagram -o without_adding_font.html sample_including_japanese.adoc 
bash-5.1# mv diag-de5339e47def289856ddeb2fd653f5d6.png  without_adding_font/
bash-5.1# mv without_adding_font.html without_adding_font
bash-5.1# ls
sample_including_japanese.adoc  without_adding_font
bash-5.1# mkdir adding_font
bash-5.1# apk add font-noto-cjk
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/1) Installing font-noto-cjk (0_git20181130-r1)
Executing fontconfig-2.13.1-r3.trigger
Executing mkfontscale-1.2.1-r1.trigger
OK: 312 MiB in 132 packages
bash-5.1# asciidoctor -r asciidoctor-diagram -o adding_font.html sample_including_japanese.adoc
bash-5.1# ls
adding_font                                diag-de5339e47def289856ddeb2fd653f5d6.png  without_adding_font
adding_font.html                           sample_including_japanese.adoc
bash-5.1# mv adding_font.html adding_font
bash-5.1# mv diag-de5339e47def289856ddeb2fd653f5d6.png adding_font/
bash-5.1# 
```

