### PR TITLE
chore: deploy by pushing to DockerHub

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,7 +1,13 @@
-name: CI
+name: "Build and Deploy"
 on:
   ## Events from external actor, or from code pushed (includes tags pushed)
   push:
+    branches:
+      - main
+      - 'refs/tags/*'
+    tags:
+      - '*'
+
   pull_request:
   ## Events from the GitHub UI (as when publishing a release)
   # When a release is "released" (draft or released published, no pre-release) - https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#release
@@ -19,10 +25,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Define custom env variables
         run: |
-          echo "CACHE_REGISTRY_PREFIX=${CACHE_REGISTRY}/asciidoctor" >> $GITHUB_ENV
+          echo "CACHE_REGISTRY_PREFIX=${CACHE_REGISTRY}/${GITHUB_ACTOR}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to Docker Hub
+      - name: Login to Cache Registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.CACHE_REGISTRY }}
@@ -42,16 +48,22 @@ jobs:
           sudo apt-get install -y --no-install-recommends bats
       - name: Test
         run: make test
-      - name: Set up Git user for deploy and custom README
-        run: |
-          git config --local user.name "${GITHUB_ACTOR}"
-          git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
       - name: Generate README
         run: make README
+      #### Deployment Zone: only on main branch
+      - name: Login to Docker Hub for Deployment
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Deploy
         if: github.event_name != 'pull_request'
         env:
-          DOCKERHUB_SOURCE_TOKEN: ${{ secrets.DOCKERHUB_SOURCE_TOKEN }}
-          DOCKERHUB_TRIGGER_TOKEN: ${{ secrets.DOCKERHUB_TRIGGER_TOKEN }}
-          DOCKERHUB_FINAL_IMAGE_NAME: "${GITHUB_ACTOR}"
-        run: make deploy-README deploy
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          export IMAGE_VERSION="$(echo ${GITHUB_REF#refs/tags/} | grep -v 'refs/heads')"
+          export IMAGE_NAME="${DOCKERHUB_USERNAME}/docker-asciidoctor"
+          git config --local user.name "${GITHUB_ACTOR}"
+          git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          make deploy-README deploy

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,5 @@
 ---
-name: Release Drafter
+name: "Release Drafter"
 
 on:
   push:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,5 +1,5 @@
 ---
-name: Updatecli
+name: "Check for Dependencies Updates"
 
 on:
   ## Check for dependencies update daily, at 00:00 UTC

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,6 +2,14 @@ variable "CACHE_REGISTRY_PREFIX" {
   default = "ghcr.io/asciidoctor"
 }
 
+variable "IMAGE_VERSION" {
+  default = ""
+}
+
+variable "IMAGE_NAME" {
+  default = "asciidoctor"
+}
+
 group "all" {
   targets = [
     "asciidoctor-minimal",
@@ -14,9 +22,6 @@ target "asciidoctor-minimal" {
   dockerfile = "Dockerfile"
   context = "."
   target = "main-minimal"
-  tags = [
-    "asciidoctor-minimal", // Required for test harness
-  ]
   cache-from = [
     "${CACHE_REGISTRY_PREFIX}/asciidoctor-minimal:cache",
   ]
@@ -43,7 +48,10 @@ target "asciidoctor" {
   context = "."
   target = "main"
   tags = [
-    "asciidoctor", // Required for test harness
+    "${IMAGE_NAME}",
+    notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${IMAGE_VERSION}" : "", // Only used when deploying on a tag
+    notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${element(split(".", IMAGE_VERSION), 0)}" : "", // Only used when deploying on a tag (1 digit)
+    notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${element(split(".", IMAGE_VERSION), 0)}.${element(split(".", IMAGE_VERSION), 1)}" : "", // Only used when deploying on a tag (2 digits)
   ]
   cache-from = [
     "${CACHE_REGISTRY_PREFIX}/asciidoctor:cache",

--- a/tests/asciidoctor.bats
+++ b/tests/asciidoctor.bats
@@ -2,7 +2,7 @@
 
 TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
 TESTS_ENV_FILE="${BATS_TEST_DIRNAME}/env_vars.yml"
-DOCKER_IMAGE_NAME_TO_TEST="asciidoctor"
+DOCKER_IMAGE_NAME_TO_TEST="${IMAGE_NAME:-asciidoctor}"
 
 ## Load environment variables from file
 if [ -n "${TESTS_ENV_FILE}" ] && [ -f "${TESTS_ENV_FILE}" ]
@@ -12,8 +12,6 @@ then
   sed -e 's/:[^:\/\/]/="/g;s/$/"/g;s/ *=/=/g' "${TESTS_ENV_FILE}" > "${TMP_ENV_FILE}"
   source "${TMP_ENV_FILE}"
 fi
-
-[ -n "${DOCKER_IMAGE_NAME_TO_TEST}" ] || export DOCKER_IMAGE_NAME_TO_TEST=asciidoctor/docker-asciidoctor
 
 clean_generated_files() {
   docker run -t --rm -v "${BATS_TEST_DIRNAME}:${BATS_TEST_DIRNAME}" alpine \


### PR DESCRIPTION
This PR aims at improving the deployment speed and simplifying it.

It introduces the following changes:

* Switch deployment to a `docker push` instead of a [Docker Hub Automated Build](https://docs.docker.com/docker-hub/builds/) triggered by a `curl` request:
  - Time between a release is created, and the associated tagged image is available on the Docker Hub is shortened: image push is done immediately by the GitHub action workflow's Deploy step (before, we had to wait for the automated build to rebuild the image)
  - Faster deploy step: Deployment benefits from the layer caching as only the changed layers are pushed
  - What you pull is what we tested: the image tested by the test harness is the image seen by end users. Not that we ever have any issue on this, but it's a consequence of this PR changes
  - Loosed coupling from the Docker Hub
  - No consequences on the "user trust" ("As a end user pulling a tagged image, how can I know what is inside the image?") as the Docker Hub no longer maps a given image tag to a source `Dockerfile`, but instead it provides a layer details view: [example for the tag `1.7.0`](https://hub.docker.com/layers/asciidoctor/docker-asciidoctor/1.7.0/images/sha256-7105b566efe746f22761722c678a4a5ba3ba41d7cc5656d726e3bed149dc9528?context=explore)

* Simplifies the Continuous Delivery process:
  - Move all the "tagging and naming" logic on the `docker-bake.hcl` to allow contributions (as it was a set of configurations in the Docker Hub, not visible)
  - Restrict builds on tags and on the principal branch (`main`) as we did not had any use case for deploying an image tagged from a branch name

* Add debug information for the `docker buildx bake` command by printing on the stdout the configuration before executing it: it helps when checking the environment variables for naming / tagging

Please note that after merging this PR, the Docker Hub will be configured to keep an automated build from the principal branch only, mapping to the `latest` image, with no `curl` requests (e.g. Docker Hub will watch for GitHub source changes):

* Alas, access token cannot be used to automate the update of the README as per <https://github.com/docker/roadmap/issues/115>. A specific issue will be opened to discuss the next steps on this topic (removing markdown and manually pointing to the doc, moving to Antora doc, etc.) if the PR is merged. So we need to keep updating the `README` from the latest branch.
* The Docker Hub still provides a "Dockerfile" view that maps to the source for the `latest` tag. This view is generated by Automated builds, hence the need to keep it at least for the `latest` tag.
* This isn't mutually exclusive with the `docker push` as this PR is focuses on the tagged version ("Friends don't let friends use latest")
