### PR TITLE
fix: downgrade Alpine Linux to 3.13.5 to fix #214 and fix #215

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.14.0 AS base
+ARG alpine_version=3.13.5
+FROM alpine:${alpine_version} AS base
 
 ARG asciidoctor_version=2.0.15
 ARG asciidoctor_confluence_version=0.0.2
@@ -62,7 +63,7 @@ RUN apk add --no-cache \
     zlib-dev
 
 RUN cabal v2-update \
- && cabal v2-install erd
+  && cabal v2-install erd
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/README-original.adoc
+++ b/README-original.adoc
@@ -22,7 +22,7 @@ This Docker image provides:
 * https://github.com/asciidoctor/asciidoctor-confluence[Asciidoctor Confluence] {ASCIIDOCTOR_CONFLUENCE_VERSION}
 * https://github.com/asciidoctor/asciidoctor-bibtex[Asciidoctor Bibtex] {ASCIIDOCTOR_BIBTEX_VERSION}
 
-This image uses Alpine Linux 3.13 as base image.
+This image uses Alpine Linux {ALPINE_VERSION} as base image.
 
 == How to use it
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,4 @@
+:ALPINE_VERSION: 3.13.5
 :ASCIIDOCTOR_VERSION: 2.0.15
 :ASCIIDOCTOR_CONFLUENCE_VERSION: 0.0.2
 :ASCIIDOCTOR_PDF_VERSION: 1.6.0
@@ -6,7 +7,7 @@
 :ASCIIDOCTOR_FB2_VERSION: 0.5.1
 :ASCIIDOCTOR_MATHEMATICAL_VERSION: 0.3.5
 :ASCIIDOCTOR_REVEALJS_VERSION: 4.1.0
-:KRAMDOWN_ASCIIDOC_VERSION: 1.0.1
+:KRAMDOWN_ASCIIDOC_VERSION: 2.0.0
 :ASCIIDOCTOR_BIBTEX_VERSION: 0.8.0
 = Asciidoctor Docker Container
 :source-highlighter: coderay
@@ -32,7 +33,7 @@ This Docker image provides:
 * https://github.com/asciidoctor/asciidoctor-confluence[Asciidoctor Confluence] {ASCIIDOCTOR_CONFLUENCE_VERSION}
 * https://github.com/asciidoctor/asciidoctor-bibtex[Asciidoctor Bibtex] {ASCIIDOCTOR_BIBTEX_VERSION}
 
-This image uses Alpine Linux 3.13 as base image.
+This image uses Alpine Linux {ALPINE_VERSION} as base image.
 
 == How to use it
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Docker image provides:
 
 -   [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.8.0
 
-This image uses Alpine Linux 3.13 as base image.
+This image uses Alpine Linux 3.13.5 as base image.
 
 ## How to use it
 

--- a/tests/env_vars.yml
+++ b/tests/env_vars.yml
@@ -1,5 +1,6 @@
 ## This file holds the environement variables for the test harness
 # Only key/value at level 0 are allowed
+ALPINE_VERSION: 3.13.5
 ASCIIDOCTOR_VERSION: 2.0.15
 ASCIIDOCTOR_CONFLUENCE_VERSION: 0.0.2
 ASCIIDOCTOR_PDF_VERSION: 1.6.0

--- a/updatecli/updatecli.d/alpine-linux.yml
+++ b/updatecli/updatecli.d/alpine-linux.yml
@@ -10,18 +10,19 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
+        kind: regex
+        pattern: '3.13.(\d*)'
     transformers:
       - trimPrefix: "v"
 conditions:
-  testDockerfileFrom:
-    name: "Does the Dockerfile have a FROM instruction which image is alpine?"
+  testDockerfileArg:
+    name: "Does the Dockerfile have an ARG instruction for the Alpine Linux version?"
     kind: dockerfile
     spec:
       file: Dockerfile
       instruction:
-        keyword: "FROM"
-        matcher: "alpine"
+        keyword: "ARG"
+        matcher: "alpine_version"
   testDockerImageExists:
     name: "Does the Docker Image exists on the Docker Hub?"
     kind: dockerImage
@@ -29,14 +30,30 @@ conditions:
       image: "alpine"
 targets:
   updateDockerfileArgVersion:
-    name: "Update the value of the base image (FROM) in the Dockerfile"
+    name: "Update the value of the base image (ARG alpine_version) in the Dockerfile"
     sourceID: getAlpineLinuxVersion
     kind: dockerfile
     spec:
       file: Dockerfile
       instruction:
-        keyword: "FROM"
-        matcher: "alpine"
+        keyword: "ARG"
+        matcher: "alpine_version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "{{ requiredEnv .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateHarnessEnvAlpineVersion:
+    name: "Update the key ALPINE_VERSION in the test harness env_vars.yml file"
+    kind: yaml
+    sourceID: getAlpineLinuxVersion
+    spec:
+      file: "tests/env_vars.yml"
+      key: "ALPINE_VERSION"
     scm:
       github:
         user: "{{ .github.user }}"


### PR DESCRIPTION
This PR downgrades the base image from Alpine Linux 3.14.0 to 3.13.5.

It also:
* Fixes the updatecli's configuration for automatic upgrade of the Alpine Linux version, to only retrieve the latest stable version of 3.13.x (no rc, no beta)
* Fixes the documentation to mention the exact Alpine version used.

Closes #214 and #215.