### PR TITLE
chore(updatecli) use the new features from 0.17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,4 +27,29 @@ categories:
       - 'chore'
 exclude-labels:
   - 'skip-changelog'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'feat'
+      - 'improvement'
+  patch:
+    labels:
+      - 'documentation'
+      - 'doc'
+      - 'docs'
+      - 'dependencies'
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'chore'
+      - 'chores'
+  default: patch
 ...

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update_release_draft:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -26,7 +26,7 @@ jobs:
           echo "::set-output name=repo::$repo"
       ## Ensure that the updatecli configurations are valid without waiting for the daily execution from the workflow "Updatecli"
       - name: Diff
-        uses: updatecli/updatecli-action@v1
+        uses: updatecli/updatecli-action@v1.17.0
         ## Check the updatecli syntax on each code change
         if: github.event_name != 'schedule'
         with:
@@ -39,7 +39,7 @@ jobs:
       ## Open PRs to upgrade dependencies using updatecli
       - name: Apply
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        uses: updatecli/updatecli-action@v1
+        uses: updatecli/updatecli-action@v1.17.0
         with:
           command: apply
           flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"

--- a/updatecli/updatecli.d/Mogztter-kroki.yml
+++ b/updatecli/updatecli.d/Mogztter-kroki.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Kroki version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-Kroki version"
     spec:
@@ -14,6 +27,7 @@ sources:
         pattern: 'ruby-*'
     transformers:
       - trimPrefix: "ruby-v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_kroki_version?"
@@ -35,6 +49,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_KROKI_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_kroki_version in the Dockerfile"
@@ -44,44 +59,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_kroki_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_KROKI_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_KROKI_VERSION=.*)'
-      content: 'ASCIIDOCTOR_KROKI_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_KROKI_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_KROKI_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_KROKI_VERSION:.*)'
-      content: ':ASCIIDOCTOR_KROKI_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_KROKI_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/alpine-linux.yml
+++ b/updatecli/updatecli.d/alpine-linux.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Alpine Linux Version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Alpine Linux version"
     spec:
@@ -15,6 +28,7 @@ sources:
         pattern: '3.13.(\d*)'
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArg:
     name: "Does the Dockerfile have an ARG instruction for the Alpine Linux version?"
@@ -41,6 +55,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ALPINE_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of the base image (ARG alpine_version) in the Dockerfile"
@@ -50,44 +65,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "alpine_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ALPINE_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ALPINE_VERSION=.*)'
-      content: 'ALPINE_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ALPINE_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ALPINE_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ALPINE_VERSION:.*)'
-      content: ':ALPINE_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ALPINE_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-bibtex.yml
+++ b/updatecli/updatecli.d/asciidoctor-bibtex.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Bibtex version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-Bibtex version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_bibtex_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_BIBTEX_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_bibtex_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_bibtex_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_BIBTEX_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_BIBTEX_VERSION=.*)'
-      content: 'ASCIIDOCTOR_BIBTEX_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_BIBTEX_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_BIBTEX_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_BIBTEX_VERSION:.*)'
-      content: ':ASCIIDOCTOR_BIBTEX_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_BIBTEX_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-diagram.yml
+++ b/updatecli/updatecli.d/asciidoctor-diagram.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Diagram version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-Diagram version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_diagram_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_DIAGRAM_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_diagram_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_diagram_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_DIAGRAM_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_DIAGRAM_VERSION=.*)'
-      content: 'ASCIIDOCTOR_DIAGRAM_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_DIAGRAM_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_DIAGRAM_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_DIAGRAM_VERSION:.*)'
-      content: ':ASCIIDOCTOR_DIAGRAM_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_DIAGRAM_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-epub3.yml
+++ b/updatecli/updatecli.d/asciidoctor-epub3.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Epub3 version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-Epub3 version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_epub3_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_EPUB3_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_epub3_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_epub3_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_EPUB3_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_EPUB3_VERSION=.*)'
-      content: 'ASCIIDOCTOR_EPUB3_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_EPUB3_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_EPUB3_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_EPUB3_VERSION:.*)'
-      content: ':ASCIIDOCTOR_EPUB3_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_EPUB3_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-fb2.yml
+++ b/updatecli/updatecli.d/asciidoctor-fb2.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Fb2 version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest asciidoctor-fb2 version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_fb2_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_FB2_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_fb2_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_fb2_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_FB2_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_FB2_VERSION=.*)'
-      content: 'ASCIIDOCTOR_FB2_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_FB2_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_FB2_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_FB2_VERSION:.*)'
-      content: ':ASCIIDOCTOR_FB2_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_FB2_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-kramdown.yml
+++ b/updatecli/updatecli.d/asciidoctor-kramdown.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Kramdown version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-Kramdown version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is kramdown_asciidoc_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^KRAMDOWN_ASCIIDOC_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG kramdown_asciidoc_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "kramdown_asciidoc_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key KRAMDOWN_ASCIIDOC_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^KRAMDOWN_ASCIIDOC_VERSION=.*)'
-      content: 'KRAMDOWN_ASCIIDOC_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'KRAMDOWN_ASCIIDOC_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key KRAMDOWN_ASCIIDOC_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:KRAMDOWN_ASCIIDOC_VERSION:.*)'
-      content: ':KRAMDOWN_ASCIIDOC_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':KRAMDOWN_ASCIIDOC_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-mathematical.yml
+++ b/updatecli/updatecli.d/asciidoctor-mathematical.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Mathematical version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-Mathematical version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_mathematical_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_MATHEMATICAL_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_mathematical_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_mathematical_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_MATHEMATICAL_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_MATHEMATICAL_VERSION=.*)'
-      content: 'ASCIIDOCTOR_MATHEMATICAL_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_MATHEMATICAL_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_MATHEMATICAL_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_MATHEMATICAL_VERSION:.*)'
-      content: ':ASCIIDOCTOR_MATHEMATICAL_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_MATHEMATICAL_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-pdf.yml
+++ b/updatecli/updatecli.d/asciidoctor-pdf.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-PDF version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-PDF version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_pdf_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_PDF_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_pdf_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_pdf_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_PDF_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_PDF_VERSION=.*)'
-      content: 'ASCIIDOCTOR_PDF_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_PDF_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_PDF_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_PDF_VERSION:.*)'
-      content: ':ASCIIDOCTOR_PDF_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_PDF_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor-revealjs.yml
+++ b/updatecli/updatecli.d/asciidoctor-revealjs.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor-Revealjs version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor-Revealjs version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_revealjs_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_REVEALJS_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_revealjs_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_revealjs_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_REVEALJS_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_REVEALJS_VERSION=.*)'
-      content: 'ASCIIDOCTOR_REVEALJS_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_REVEALJS_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_REVEALJS_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_REVEALJS_VERSION:.*)'
-      content: ':ASCIIDOCTOR_REVEALJS_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_REVEALJS_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies

--- a/updatecli/updatecli.d/asciidoctor.yml
+++ b/updatecli/updatecli.d/asciidoctor.yml
@@ -1,7 +1,20 @@
 ---
 title: "Bump Asciidoctor version"
-sources:
+
+scms:
   default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
     kind: githubRelease
     name: "Get the latest Asciidoctor version"
     spec:
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_version?"
@@ -34,6 +48,7 @@ conditions:
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_VERSION=.*)'
+
 targets:
   updateDockerfile:
     name: "Update the value of ARG asciidoctor_version in the Dockerfile"
@@ -43,44 +58,33 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "asciidoctor_version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateTestHarness:
     name: "Update the key ASCIIDOCTOR_VERSION in the test harness"
     kind: file
     spec:
       file: tests/asciidoctor.bats
       matchPattern: '(?m:^ASCIIDOCTOR_VERSION=.*)'
-      content: 'ASCIIDOCTOR_VERSION={{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: 'ASCIIDOCTOR_VERSION={{ source `latestVersion` }}'
+    scmID: default
   updateReadme:
     name: "Update the key ASCIIDOCTOR_VERSION in the README.adoc file"
     kind: file
     spec:
       file: README.adoc
       matchPattern: '(?m:^:ASCIIDOCTOR_VERSION:.*)'
-      content: ':ASCIIDOCTOR_VERSION: {{ source `default` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ requiredEnv .github.owner }}"
-        repository: "{{ requiredEnv .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+      content: ':ASCIIDOCTOR_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies


### PR DESCRIPTION
This PR includes the following changes:

- Update syntax of updatecli manifests to ensure there are no warning and that we automatically add labels to updatecli's PRs
- Enable dependabot to auto-upgrade github actions (including updatecli's)
- Fine tune release-drafter to allow manual trigger and to define version increments based on labels