### PR TITLE
Add Trivy CVE scan info to README

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,2 +1,0 @@
-general:
-  vulnerabilities: [] # List of excluded CVEs (e.g: CVE-2021-3711)

--- a/README.adoc
+++ b/README.adoc
@@ -119,6 +119,7 @@ You need the following tools:
 * link:http://man7.org/linux/man-pages/man1/make.1.html[GNU make]
 * link:https://github.com/sstephenson/bats[Bats] installed and in your bash PATH
 * Docker installed and in your path
+* link:https://github.com/aquasecurity/trivy[Trivy] cli in case you want to scan images for vulnerabilities
 
 === How to build and test?
 
@@ -142,6 +143,21 @@ Optionally, you can specify a custom image name:
 export DOCKER_IMAGE_NAME_TO_TEST=your-image-name
 bats tests/*.bats
 ----
+
+=== How to scan for vulnerabilities?
+
+* Trivy scans a docker image looking for software versions containing known vulnerabilities (CVEs).
+It's always a good idea to scan the image to ensure no new issues are introduced.
+
+* Run the following command to replicate the repo's `CVE Scan` pipeline on an image build locally.
+Note the pipeline runs nightly on the latest release version, so it can display issues solved in main branch.
++
+[source,bash]
+----
+trivy image --severity HIGH,CRITICAL asciidoctor:latest
+----
+
+
 
 ==== Deploy
 


### PR DESCRIPTION
Continuing work from https://github.com/asciidoctor/docker-asciidoctor/pull/237#pullrequestreview-874300559.
However, I found the officicial trivy image does not support ignoring CVEs out of the box, there's an issue and I'll see to find to time to work on it https://github.com/aquasecurity/trivy-action/issues/91 next week.

* Add 'how-to' scan local image
* Remove leftover files from 'Azure/container-scan' initial developments