### PR TITLE
Adds support for asciidoctor-lists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ARG asciidoctor_revealjs_version=4.1.0
 ARG kramdown_asciidoc_version=2.0.0
 ARG asciidoctor_bibtex_version=0.8.0
 ARG asciidoctor_kroki_version=0.5.0
+ARG asciidoctor_lists_version=1.0.7
 
 ENV ASCIIDOCTOR_VERSION=${asciidoctor_version} \
   ASCIIDOCTOR_CONFLUENCE_VERSION=${asciidoctor_confluence_version} \
@@ -23,7 +24,8 @@ ENV ASCIIDOCTOR_VERSION=${asciidoctor_version} \
   ASCIIDOCTOR_REVEALJS_VERSION=${asciidoctor_revealjs_version} \
   KRAMDOWN_ASCIIDOC_VERSION=${kramdown_asciidoc_version} \
   ASCIIDOCTOR_BIBTEX_VERSION=${asciidoctor_bibtex_version} \
-  ASCIIDOCTOR_KROKI_VERSION=${asciidoctor_kroki_version}
+  ASCIIDOCTOR_KROKI_VERSION=${asciidoctor_kroki_version} \
+  ASCIIDOCTOR_LISTS_VERSION=${asciidoctor_lists_version}
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Minimal image with asciidoctor
@@ -127,6 +129,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
     text-hyphen \
     "asciidoctor-bibtex:${ASCIIDOCTOR_BIBTEX_VERSION}" \
     "asciidoctor-kroki:${ASCIIDOCTOR_KROKI_VERSION}" \
+    "asciidoctor-lists:${ASCIIDOCTOR_LISTS_VERSION}" \
   && apk del -r --no-cache .rubymakedepends
 
 # Installing Python dependencies for additional functionality

--- a/README.md
+++ b/README.md
@@ -4,29 +4,31 @@
 
 This Docker image provides:
 
--   [Asciidoctor](https://asciidoctor.org/) 2.0.17
+- [Asciidoctor](https://asciidoctor.org/) 2.0.17
 
--   [Asciidoctor Diagram](https://asciidoctor.org/docs/asciidoctor-diagram/) 2.2.1 with ERD and Graphviz integration (supports plantuml and graphiz diagrams)
+- [Asciidoctor Diagram](https://asciidoctor.org/docs/asciidoctor-diagram/) 2.2.1 with ERD and Graphviz integration (supports plantuml and graphiz diagrams)
 
--   [Asciidoctor PDF](https://asciidoctor.org/docs/asciidoctor-pdf/) 1.6.2
+- [Asciidoctor PDF](https://asciidoctor.org/docs/asciidoctor-pdf/) 1.6.2
 
--   [Asciidoctor EPUB3](https://asciidoctor.org/docs/asciidoctor-epub3/) 1.5.1
+- [Asciidoctor EPUB3](https://asciidoctor.org/docs/asciidoctor-epub3/) 1.5.1
 
--   [Asciidoctor FB2](https://github.com/asciidoctor/asciidoctor-fb2/) 0.5.1
+- [Asciidoctor FB2](https://github.com/asciidoctor/asciidoctor-fb2/) 0.5.1
 
--   [Asciidoctor Mathematical](https://github.com/asciidoctor/asciidoctor-mathematical) 0.3.5
+- [Asciidoctor Mathematical](https://github.com/asciidoctor/asciidoctor-mathematical) 0.3.5
 
--   [Asciidoctor reveal.js](https://docs.asciidoctor.org/reveal.js-converter/latest/) 4.1.0
+- [Asciidoctor reveal.js](https://docs.asciidoctor.org/reveal.js-converter/latest/) 4.1.0
 
--   [AsciiMath](https://rubygems.org/gems/asciimath)
+- [AsciiMath](https://rubygems.org/gems/asciimath)
 
--   Source highlighting using [Rouge](http://rouge.jneen.net), [CodeRay](https://rubygems.org/gems/coderay) or [Pygments](https://pygments.org/)
+- Source highlighting using [Rouge](http://rouge.jneen.net), [CodeRay](https://rubygems.org/gems/coderay) or [Pygments](https://pygments.org/)
 
--   [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
+- [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
 
--   [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.8.0
+- [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.8.0
 
--   [Asciidoctor Kroki](https://github.com/Mogztter/asciidoctor-kroki) 0.5.0
+- [Asciidoctor Kroki](https://github.com/Mogztter/asciidoctor-kroki) 0.5.0
+
+- [Asciidoctor Lists](https://github.com/Alwinator/asciidoctor-lists) 1.0.7
 
 This image uses Alpine Linux 3.15.4 as base image.
 

--- a/README.md
+++ b/README.md
@@ -4,31 +4,31 @@
 
 This Docker image provides:
 
-- [Asciidoctor](https://asciidoctor.org/) 2.0.17
+-   [Asciidoctor](https://asciidoctor.org/) 2.0.17
 
-- [Asciidoctor Diagram](https://asciidoctor.org/docs/asciidoctor-diagram/) 2.2.1 with ERD and Graphviz integration (supports plantuml and graphiz diagrams)
+-   [Asciidoctor Diagram](https://asciidoctor.org/docs/asciidoctor-diagram/) 2.2.1 with ERD and Graphviz integration (supports plantuml and graphiz diagrams)
 
-- [Asciidoctor PDF](https://asciidoctor.org/docs/asciidoctor-pdf/) 1.6.2
+-   [Asciidoctor PDF](https://asciidoctor.org/docs/asciidoctor-pdf/) 1.6.2
 
-- [Asciidoctor EPUB3](https://asciidoctor.org/docs/asciidoctor-epub3/) 1.5.1
+-   [Asciidoctor EPUB3](https://asciidoctor.org/docs/asciidoctor-epub3/) 1.5.1
 
-- [Asciidoctor FB2](https://github.com/asciidoctor/asciidoctor-fb2/) 0.5.1
+-   [Asciidoctor FB2](https://github.com/asciidoctor/asciidoctor-fb2/) 0.5.1
 
-- [Asciidoctor Mathematical](https://github.com/asciidoctor/asciidoctor-mathematical) 0.3.5
+-   [Asciidoctor Mathematical](https://github.com/asciidoctor/asciidoctor-mathematical) 0.3.5
 
-- [Asciidoctor reveal.js](https://docs.asciidoctor.org/reveal.js-converter/latest/) 4.1.0
+-   [Asciidoctor reveal.js](https://docs.asciidoctor.org/reveal.js-converter/latest/) 4.1.0
 
-- [AsciiMath](https://rubygems.org/gems/asciimath)
+-   [AsciiMath](https://rubygems.org/gems/asciimath)
 
 - Source highlighting using [Rouge](http://rouge.jneen.net), [CodeRay](https://rubygems.org/gems/coderay) or [Pygments](https://pygments.org/)
 
-- [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
+-   [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
 
-- [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.8.0
+-   [Asciidoctor Bibtex](https://github.com/asciidoctor/asciidoctor-bibtex) 0.8.0
 
-- [Asciidoctor Kroki](https://github.com/Mogztter/asciidoctor-kroki) 0.5.0
+-   [Asciidoctor Kroki](https://github.com/Mogztter/asciidoctor-kroki) 0.5.0
 
-- [Asciidoctor Lists](https://github.com/Alwinator/asciidoctor-lists) 1.0.7
+-   [Asciidoctor Lists](https://github.com/Alwinator/asciidoctor-lists) 1.0.7
 
 This image uses Alpine Linux 3.15.4 as base image.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This Docker image provides:
 
 -   [AsciiMath](https://rubygems.org/gems/asciimath)
 
-- Source highlighting using [Rouge](http://rouge.jneen.net), [CodeRay](https://rubygems.org/gems/coderay) or [Pygments](https://pygments.org/)
+-   Source highlighting using [Rouge](http://rouge.jneen.net), [CodeRay](https://rubygems.org/gems/coderay) or [Pygments](https://pygments.org/)
 
 -   [Asciidoctor Confluence](https://github.com/asciidoctor/asciidoctor-confluence) 0.0.2
 

--- a/tests/asciidoctor.bats
+++ b/tests/asciidoctor.bats
@@ -13,6 +13,7 @@ ASCIIDOCTOR_REVEALJS_VERSION=4.1.0
 KRAMDOWN_ASCIIDOC_VERSION=2.0.0
 ASCIIDOCTOR_BIBTEX_VERSION=0.8.0
 ASCIIDOCTOR_KROKI_VERSION=0.5.0
+ASCIIDOCTOR_LISTS_VERSION=1.0.7
 DOCKER_IMAGE_NAME_TO_TEST="${IMAGE_NAME:-asciidoctor}"
 
 clean_generated_files() {
@@ -302,4 +303,13 @@ teardown() {
       /documents/fixtures/sample-with-bib.adoc
 
   grep 'Mane' ${TMP_GENERATION_DIR}/sample-with-bib.html
+}
+
+@test "We can use asciidoctor-lists" {
+  docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
+      asciidoctor -r asciidoctor-lists \
+      -o /documents/tmp/sample-with-lists.html \
+      /documents/fixtures/sample-with-lists.adoc
 }

--- a/tests/asciidoctor.bats
+++ b/tests/asciidoctor.bats
@@ -312,4 +312,11 @@ teardown() {
       asciidoctor -r asciidoctor-lists \
       -o /documents/tmp/sample-with-lists.html \
       /documents/fixtures/sample-with-lists.adoc
+
+  docker run -t --rm \
+      -v "${BATS_TEST_DIRNAME}":/documents/ \
+      "${DOCKER_IMAGE_NAME_TO_TEST}" \
+        asciidoctor-pdf -r asciidoctor-lists \
+        -o /documents/tmp/sample-with-lists.pdf \
+        /documents/fixtures/sample-with-lists.adoc
 }

--- a/tests/fixtures/sample-with-lists.adoc
+++ b/tests/fixtures/sample-with-lists.adoc
@@ -1,0 +1,63 @@
+= Test the List Macro
+:listing-caption: Code
+
+.Gemfile.lock
+----
+GEM
+  remote: https://rubygems.org/
+  specs:
+    asciidoctor (2.0.15)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  asciidoctor (~> 2.0.15)
+----
+
+.The wonderful linux logo
+image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[Linux Logo,100,100]
+
+.Some Ruby code
+[source,ruby]
+----
+require 'sinatra'
+
+get '/hi' do
+  "Hello World!"
+end
+----
+
+.This is my first table
+|===
+|Column 1, Header Row |Column 2, Header Row
+
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|===
+
+.And this is the second one
+|===
+|Column 1, Header Row |Column 2, Header Row
+
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|===
+
+.Another wikipedia SVG image
+image::https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/SVG_Logo.svg/400px-SVG_Logo.svg.png[SVG,100,100]
+
+== List of figures
+list-of::image[]
+
+== List of tables
+list-of::table[]
+
+== List of code snippets
+list-of::listing[]

--- a/updatecli/updatecli.d/asciidoctor-lists.yml
+++ b/updatecli/updatecli.d/asciidoctor-lists.yml
@@ -1,0 +1,90 @@
+---
+title: "Bump Asciidoctor-Lists version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "{{ requiredEnv .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubRelease
+    name: "Get the latest Asciidoctor-Lists version"
+    spec:
+      owner: "Alwinator"
+      repository: "asciidoctor-lists"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+
+conditions:
+  testDockerfileArgVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is asciidoctor_lists_version?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_lists_version"
+  testVersionInReadme:
+    name: "Does the README.adoc have a variable ASCIIDOCTOR_LISTS_VERSION"
+    kind: file
+    spec:
+      file: README.adoc
+      matchPattern: '(?m:^:ASCIIDOCTOR_LISTS_VERSION:.*)'
+  testVersionInTestHarness:
+    name: "Does the test harness have variable ASCIIDOCTOR_LISTS_VERSION"
+    kind: file
+    spec:
+      file: tests/asciidoctor.bats
+      matchPattern: '(?m:^ASCIIDOCTOR_LISTS_VERSION=.*)'
+
+targets:
+  updateDockerfile:
+    name: "Update the value of ARG asciidoctor_lists_version in the Dockerfile"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "asciidoctor_lists_version"
+    scmID: default
+  updateTestHarness:
+    name: "Update the key ASCIIDOCTOR_LISTS_VERSION in the test harness"
+    kind: file
+    spec:
+      file: tests/asciidoctor.bats
+      matchPattern: '(?m:^ASCIIDOCTOR_LISTS_VERSION=.*)'
+      content: 'ASCIIDOCTOR_LISTS_VERSION={{ source `latestVersion` }}'
+    scmID: default
+  updateReadme:
+    name: "Update the key ASCIIDOCTOR_LISTS_VERSION in the README.adoc file"
+    kind: file
+    spec:
+      file: README.adoc
+      matchPattern: '(?m:^:ASCIIDOCTOR_LISTS_VERSION:.*)'
+      content: ':ASCIIDOCTOR_LISTS_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfile
+      - updateTestHarness
+      - updateReadme
+    spec:
+      labels:
+        - chore
+        - dependencies


### PR DESCRIPTION
[asciidoctor-lists](https://github.com/Alwinator/asciidoctor-lists) is a lightweight asciidoctor extension that adds a list of figures, a list of tables, or a list of anything you want! It is convinient and because it is used by more and more people I think it would make sense to directly include it in the docker-asciidoctor.