### PR TITLE
only run scheduled workflows on upstream repository

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -2,10 +2,11 @@ name: "CVE Scan"
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch: { }
+  workflow_dispatch:
 jobs:
   scan-images:
     name: Scan latest public image
+    if: github.repository_owner == 'asciidoctor' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 jobs:
   updatecli:
+    if: github.repository_owner == 'asciidoctor' || github.event_name != 'schedule'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This change prevents scheduled workflows from running on forks. A fork should not be running scheduled jobs.