### PR TITLE
chore(gha) pin buildx version to 0.9.1

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,6 +28,8 @@ jobs:
           echo "CACHE_REGISTRY_PREFIX=${CACHE_REGISTRY}/asciidoctor" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
       - name: Login to Cache Registry
         uses: docker/login-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This Docker image provides:
 
 -   [Asciidoctor Reducer](https://github.com/asciidoctor/asciidoctor-reducer) 1.0.2
 
-This image uses Alpine Linux 3.16.3 as base image.
+This image uses Alpine Linux 3.17.1 as base image.
 
 <div class="note">
 


### PR DESCRIPTION
The version [0.10.0](https://github.com/docker/buildx/releases/tag/v0.10.0) of Docker BuildX introduced new behaviors that seems to break our build with the error message

```
ERROR: registry cache exporter requires ref
``` 

when calling the target `make build` (the command `docker buildx bake asciidoctor-minimal --load --set '*.cache-to=""'` is executed and responds with the error message above).

This PR is a short term fix to ensure we can keep delivering the asciidoctor image until we can properly fix this (which will happen soon : when Docker Desktop will be updated with the new 0.10.x  buildx plugin, no contributor will be able to build locally).