### PR TITLE
chore: remove intermediate caching to surface dependency issues

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,32 +18,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    env:
-      CACHE_REGISTRY: ghcr.io
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Define custom env variables
-        run: |
-          echo "CACHE_REGISTRY_PREFIX=${CACHE_REGISTRY}/asciidoctor" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
           version: v0.9.1
-      - name: Login to Cache Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.CACHE_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: |
           make build
-      - name: Deploy Cache
-        # Only upstream has the cache registry credential as PRs cannot be trusted
-        if: github.event_name != 'pull_request'
-        run: |
-          make docker-cache
       - name: Install dependencies for Tests
         run: |
           sudo apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ FROM alpine:${alpine_version} AS base
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 FROM base AS main-minimal
-RUN echo "assemble minimal main image" # keep here to help --cache-from along
 
 LABEL maintainers="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/asciidoctor/docker-asciidoctor"
@@ -44,8 +43,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build
 # Final image
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 FROM main-minimal AS main
-RUN echo "assemble comprehensive main image" # keep here to help --cache-from along
-
 LABEL maintainers="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 
 ## Always use the latest dependencies versions available for the current Alpine distribution

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,8 @@ all: build test README
 build: asciidoctor-minimal.build erd-builder.build asciidoctor.build
 
 %.build:
-	docker buildx bake $(*) --load --set '*.cache-to=""' --print
-	docker buildx bake $(*) --load --set '*.cache-to=""'
-
-docker-cache: asciidoctor-minimal.docker-cache erd-builder.docker-cache asciidoctor.docker-cache
-
-%.docker-cache:
-	docker buildx bake $(*) --print
-	docker buildx bake $(*)
+	docker buildx bake $(*) --load --print
+	docker buildx bake $(*) --load
 
 test: asciidoctor.test
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,7 +1,3 @@
-variable "CACHE_REGISTRY_PREFIX" {
-  default = "ghcr.io/asciidoctor"
-}
-
 variable "IMAGE_VERSION" {
   default = ""
 }
@@ -22,12 +18,6 @@ target "asciidoctor-minimal" {
   dockerfile = "Dockerfile"
   context = "."
   target = "main-minimal"
-  cache-from = [
-    "${CACHE_REGISTRY_PREFIX}/asciidoctor-minimal:cache",
-  ]
-  cache-to = [
-    "${CACHE_REGISTRY_PREFIX}/asciidoctor-minimal:cache",
-  ]
 }
 
 // This image is only used for intermediate steps
@@ -35,12 +25,6 @@ target "erd-builder" {
   dockerfile = "Dockerfile"
   context = "."
   target = "erd-builder"
-  cache-from = [
-    "${CACHE_REGISTRY_PREFIX}/erd-builder:cache",
-  ]
-  cache-to = [
-    "${CACHE_REGISTRY_PREFIX}/erd-builder:cache",
-  ]
 }
 
 target "asciidoctor" {
@@ -52,11 +36,5 @@ target "asciidoctor" {
     notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${IMAGE_VERSION}" : "", // Only used when deploying on a tag
     notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${element(split(".", IMAGE_VERSION), 0)}" : "", // Only used when deploying on a tag (1 digit)
     notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${element(split(".", IMAGE_VERSION), 0)}.${element(split(".", IMAGE_VERSION), 1)}" : "", // Only used when deploying on a tag (2 digits)
-  ]
-  cache-from = [
-    "${CACHE_REGISTRY_PREFIX}/asciidoctor:cache",
-  ]
-  cache-to = [
-    "${CACHE_REGISTRY_PREFIX}/asciidoctor:cache",
   ]
 }


### PR DESCRIPTION
The PR #356 had its "Build" check failing due to a python dependency error, but the `main` branch's "Build" check does not.

It appears that the layer caching is the culprit by hiding the error in the cached layer.

Since #344 the caching system makes less sense so this PR removes it.


The impact on build time is not visible: tried with 3 builds and the time oscillates between 1min30 and 1min40, same as the `main` branch builds.