### PR TITLE
chore(updatecli) track 3.x.y version of Alpine Linux

### DIFF
--- a/updatecli/updatecli.d/alpine-linux.yml
+++ b/updatecli/updatecli.d/alpine-linux.yml
@@ -96,3 +96,4 @@ actions:
     spec:
       labels:
         - dependencies
+        - alpine-linux

--- a/updatecli/updatecli.d/alpine-linux.yml
+++ b/updatecli/updatecli.d/alpine-linux.yml
@@ -24,6 +24,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: semver
+        pattern: "~3"
     transformers:
       - trimprefix: "v"
 


### PR DESCRIPTION
Closes #357 

This PR ensures that Alpine Linux version is tracked by `updatecli` with only a major version constraint (`3.x.y`)

Once merged, a new PR should be automatically opened to propose an upgrade to Alpine Linux 3.18.0.