### PR TITLE
docs: add user option to Docker examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ Just run:
 
 [source,bash]
 ----
-docker run -it -v <your directory>:/documents/ asciidoctor/docker-asciidoctor
+docker run -it -u $(id -u):$(id -g) -v <your directory>:/documents/ asciidoctor/docker-asciidoctor
 ----
 
 or the following for https://podman.io/[Podman]:
@@ -120,7 +120,7 @@ asciidoctor-revealjs -a revealjsdir=https://cdnjs.cloudflare.com/ajax/libs/revea
 +
 [source,bash]
 ----
-docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf index.adoc
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf index.adoc
 ----
 +
 or:


### PR DESCRIPTION
This is so that the generated output files will not be owned by root in the host system. See also [this thread](https://asciidoctor.zulipchat.com/#narrow/stream/304116-users.2Fdocker-asciidoctor/topic/Output.20file.20ownership) for a discussion around this.