### PR TITLE
arm64 support

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,7 +17,11 @@ on:
   create:
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    # In the future it would be good to run the tests on amd64 and arm64
+    # This will require one of these:
+    # https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/
+    # https://github.com/marketplace/actions/arm-runner
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.9.1
+          version: v0.12.0
       - name: Build
         run: |
           make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ COPY --from=erd-builder /app/erd-go /usr/local/bin/
 RUN ln -snf /usr/local/bin/erd-go /usr/local/bin/erd
 
 # Fixes an issue with 2 nokogiri versions breaking asciidoctor-epub3 on arm64
-RUN if [[ ${TARGETARCH} == arm64 ]]; then gem uninstall nokogiri -v '1.15.5'; fi
+RUN if [[ ${TARGETARCH} == arm64 ]]; then gem uninstall nokogiri -v '1.16.0'; fi
 
 WORKDIR /documents
 VOLUME /documents

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN GOBIN=/app go install github.com/asciitosvg/asciitosvg/cmd/a2s@"${A2S_VERSIO
 FROM main-minimal AS main
 LABEL maintainers="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUPORTAL <damien.duportal@gmail.com>"
 
+ARG TARGETARCH
+
 ## Always use the latest dependencies versions available for the current Alpine distribution
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
@@ -162,6 +164,9 @@ COPY --from=a2s-builder /app/a2s /usr/local/bin/
 COPY --from=erd-builder /app/erd-go /usr/local/bin/
 # for backward compatibility
 RUN ln -snf /usr/local/bin/erd-go /usr/local/bin/erd
+
+# Fixes an issue with 2 nokogiri versions breaking asciidoctor-epub3 on arm64
+RUN if [[ ${TARGETARCH} == arm64 ]]; then gem uninstall nokogiri -v '1.15.5'; fi
 
 WORKDIR /documents
 VOLUME /documents

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 GIT_REF = $(GIT_TAG)
 endif
 ARCH = $(shell uname -m)
-LOCAL_TARGET = $(shell if [ $(ARCH) == "aarch64" ] || [ $(ARCH) == "arm64" ]; then echo "linux/arm64"; else echo "linux/amd64"; fi)
+LOCAL_TARGET = $(shell if [ $(ARCH) = "aarch64" ] || [ $(ARCH) = "arm64" ]; then echo "linux/arm64"; else echo "linux/amd64"; fi)
 BUILDER = $(shell if $$(docker buildx use asciidoctor 2> /dev/null) ; then echo "true"; else echo "false"; fi)
 
 PANDOC_VERSION ?= 2.10.1
@@ -38,7 +38,7 @@ deploy: asciidoctor.deploy
 	docker buildx bake $(*) --push --builder=asciidoctor
 
 builder-init:
-	if [ $(BUILDER) == false ]; then docker buildx create --name asciidoctor --driver docker-container --use && docker buildx inspect --bootstrap; fi
+	if [ $(BUILDER) = false ]; then docker buildx create --name asciidoctor --driver docker-container --use && docker buildx inspect --bootstrap; fi
 
 clean:
 	rm -rf "$(CURDIR)/cache"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: build test README
 all-load: build-load test README
 
 build-load: builder-init asciidoctor-minimal.build-load erd-builder.build-load asciidoctor.build-load
-build: builder-init asciidoctor-minimal.build asciidoctor-minimal.build-load erd-builder.build erd-builder.build-load asciidoctor.build asciidoctor.build-load
+build: build-load asciidoctor-minimal.build erd-builder.build asciidoctor.build
 
 %.build-load:
 	docker buildx bake $(*) --set *.platform=$(LOCAL_TARGET) --load --builder=asciidoctor --print

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: build test README
 all-load: build-load test README
 
 build-load: builder-init asciidoctor-minimal.build-load erd-builder.build-load asciidoctor.build-load
-build: builder-init asciidoctor-minimal.build erd-builder.build asciidoctor.build
+build: builder-init asciidoctor-minimal.build asciidoctor-minimal.build-load erd-builder.build erd-builder.build-load asciidoctor.build asciidoctor.build-load
 
 %.build-load:
 	docker buildx bake $(*) --set *.platform=$(LOCAL_TARGET) --load --builder=asciidoctor --print

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,18 @@ else
 GIT_REF = $(GIT_TAG)
 endif
 ARCH = $(shell uname -m)
-LOCAL_TARGET = $(shell if [[ $(ARCH) == "aarch64" ]] || [[ $(ARCH) == "arm64" ]]; then echo "linux/arm64"; else echo "linux/amd64"; fi)
+LOCAL_TARGET = $(shell if [ $(ARCH) == "aarch64" ] || [ $(ARCH) == "arm64" ]; then echo "linux/arm64"; else echo "linux/amd64"; fi)
 BUILDER = $(shell if $$(docker buildx use asciidoctor 2> /dev/null) ; then echo "true"; else echo "false"; fi)
 
 PANDOC_VERSION ?= 2.10.1
 
-all: build-local test README
+all: build test README
+all-load: build-load test README
 
-build-local: builder-init asciidoctor-minimal.build-local erd-builder.build-local asciidoctor.build-local
+build-load: builder-init asciidoctor-minimal.build-load erd-builder.build-load asciidoctor.build-load
 build: builder-init asciidoctor-minimal.build erd-builder.build asciidoctor.build
 
-%.build-local:
+%.build-load:
 	docker buildx bake $(*) --set *.platform=$(LOCAL_TARGET) --load --builder=asciidoctor --print
 	docker buildx bake $(*) --set *.platform=$(LOCAL_TARGET) --load --builder=asciidoctor
 
@@ -37,7 +38,7 @@ deploy: asciidoctor.deploy
 	docker buildx bake $(*) --push --builder=asciidoctor
 
 builder-init:
-	if [[ $(BUILDER) == false ]]; then docker buildx create --name asciidoctor --driver docker-container --use && docker buildx inspect --bootstrap; fi
+	if [ $(BUILDER) == false ]; then docker buildx create --name asciidoctor --driver docker-container --use && docker buildx inspect --bootstrap; fi
 
 clean:
 	rm -rf "$(CURDIR)/cache"
@@ -62,4 +63,4 @@ deploy-README: README
 	git add README.adoc README.md && git commit -s -m "Updating README files using 'make README command'" \
 		&& git push origin $(shell git rev-parse --abbrev-ref HEAD) || echo 'No changes to README files'
 
-.PHONY: all build build-local builder-init test deploy clean README deploy-README docker-cache
+.PHONY: all build build-load builder-init test deploy clean README deploy-README docker-cache

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,24 @@ GIT_REF = $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 else
 GIT_REF = $(GIT_TAG)
 endif
+ARCH = $(shell uname -m)
+LOCAL_TARGET = $(shell if [[ $(ARCH) == "aarch64" ]] || [[ $(ARCH) == "arm64" ]]; then echo "linux/arm64"; else echo "linux/amd64"; fi)
+BUILDER = $(shell if $$(docker buildx use asciidoctor 2> /dev/null) ; then echo "true"; else echo "false"; fi)
 
 PANDOC_VERSION ?= 2.10.1
 
-all: build test README
+all: build-local test README
 
-build: asciidoctor-minimal.build erd-builder.build asciidoctor.build
+build-local: builder-init asciidoctor-minimal.build-local erd-builder.build-local asciidoctor.build-local
+build: builder-init asciidoctor-minimal.build erd-builder.build asciidoctor.build
+
+%.build-local:
+	docker buildx bake $(*) --set *.platform=$(LOCAL_TARGET) --load --builder=asciidoctor --print
+	docker buildx bake $(*) --set *.platform=$(LOCAL_TARGET) --load --builder=asciidoctor
 
 %.build:
-	docker buildx bake $(*) --load --print
-	docker buildx bake $(*) --load
+	docker buildx bake $(*) --builder=asciidoctor --print
+	docker buildx bake $(*) --builder=asciidoctor
 
 test: asciidoctor.test
 
@@ -25,8 +33,11 @@ test: asciidoctor.test
 deploy: asciidoctor.deploy
 
 %.deploy:
-	docker buildx bake $(*) --push --print
-	docker buildx bake $(*) --push
+	docker buildx bake $(*) --push --builder=asciidoctor --print
+	docker buildx bake $(*) --push --builder=asciidoctor
+
+builder-init:
+	if [[ $(BUILDER) == false ]]; then docker buildx create --name asciidoctor --driver docker-container --use && docker buildx inspect --bootstrap; fi
 
 clean:
 	rm -rf "$(CURDIR)/cache"
@@ -51,4 +62,4 @@ deploy-README: README
 	git add README.adoc README.md && git commit -s -m "Updating README files using 'make README command'" \
 		&& git push origin $(shell git rev-parse --abbrev-ref HEAD) || echo 'No changes to README files'
 
-.PHONY: all build test deploy clean README deploy-README docker-cache
+.PHONY: all build build-local builder-init test deploy clean README deploy-README docker-cache

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,22 +16,25 @@ group "all" {
 
 target "asciidoctor-minimal" {
   dockerfile = "Dockerfile"
-  context = "."
-  target = "main-minimal"
+  context    = "."
+  target     = "main-minimal"
+  platforms  = ["linux/amd64", "linux/arm64"]
 }
 
 // This image is only used for intermediate steps
 target "erd-builder" {
   dockerfile = "Dockerfile"
-  context = "."
-  target = "erd-builder"
+  context    = "."
+  target     = "erd-builder"
+  platforms  = ["linux/amd64", "linux/arm64"]
 }
 
 target "asciidoctor" {
   dockerfile = "Dockerfile"
-  context = "."
-  target = "main"
-  tags = [
+  context    = "."
+  target     = "main"
+  platforms  = ["linux/amd64", "linux/arm64"]
+  tags       = [
     "${IMAGE_NAME}",
     notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${IMAGE_VERSION}" : "", // Only used when deploying on a tag
     notequal("", IMAGE_VERSION) ? "${IMAGE_NAME}:${element(split(".", IMAGE_VERSION), 0)}" : "", // Only used when deploying on a tag (1 digit)


### PR DESCRIPTION
This supports building container images for **linux/amd64** and **linux/arm64**.

The Makefile targets needed to change a bit, as it is impossible to push multi-arch image manifests to the standard Docker Desktop instance. (`ERROR: docker exporter does not currently support exporting manifest lists`).

So, `make build-load` will now build for the local architecture and load the images into Docker, while the standard `make build` will build for all platforms and then `make deploy` should push the images to Docker Hub as usual.

A workaround was added to the `Dockerfile` to fix an issue with **nokogiri** and `asciidoctor-epub3` on arm64. The tests appear to pass fine once this workaround is in place.

The Github workflow does not currently run tests on arm64. This would likely require the [GitHub ARM64 runners](https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/) or doing the work to make this work via slower [emulation](https://github.com/marketplace/actions/arm-runner).