### PR TITLE
chore(GHA) cleanups

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,13 +40,13 @@ jobs:
         run: make README
       #### Deployment Zone: only on main branch
       - name: Login to Docker Hub for Deployment
-        if: github.event_name != 'pull_request'
+        if: contains('refs/heads/main', github.ref)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Deploy
-        if: github.event_name != 'pull_request'
+        if: contains('refs/heads/main', github.ref)
         run: |
           export IMAGE_VERSION="$(echo ${GITHUB_REF#refs/tags/} | grep -v 'refs/heads')"
           export IMAGE_NAME="asciidoctor/docker-asciidoctor"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,14 +21,12 @@ jobs:
     # This will require one of these:
     # https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/
     # https://github.com/marketplace/actions/arm-runner
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.12.0
       - name: Build
         run: |
           make build

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,7 +1,7 @@
 name: "CVE Scan"
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
   workflow_dispatch:
 jobs:
   scan-images:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
         env:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   updatecli:
     if: github.repository_owner == 'asciidoctor' || github.event_name != 'schedule'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR is only maintenance around the GHA to help maintainers. No user impact expected:

- Fix a minor issue with GHA which led to deploy the README out of the main branch 
- Ensure we use the latest version of Ubuntu runner and of the Docker Hub action
- Limit alert fatigue by running CVE scan only once a week. Yes there are CVE, no there is no available fix so we don't care at all (I wonder if a removal of the whole CVE process should not be the next step as I don't see the point of wasting GitHub runner minutes