### PR TITLE
feature: add `gnuplot`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN apk add --no-cache \
   findutils \
   font-bakoma-ttf \
   git \
+  gnuplot \
   graphviz \
   inotify-tools \
   make \

--- a/tests/fixtures/sample-with-diagram.adoc
+++ b/tests/fixtures/sample-with-diagram.adoc
@@ -221,3 +221,11 @@ drive       1--* play_player
 play        1--* play_player
 player      1--* play_player
 ----
+
+=== Gnuplot
+http://www.gnuplot.info/
+
+[gnuplot]
+....
+plot sin(x)
+....


### PR DESCRIPTION
asciidoctor-diagram expects gnuplot to be installed.
This PR:
-  adds a gnuplot section in asciidoctor-diagram adoc example for tests.
-  installs gnuplot