### PR TITLE
Feature/diagram tikz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,12 +79,17 @@ RUN apk add --no-cache \
   ruby-ffi \
   ruby-mathematical \
   ruby-rake \
+  texlive \
+  texmf-dist-latexextra \
   ttf-liberation \
   ttf-dejavu \
   tzdata \
   unzip \
   which \
   font-noto-cjk
+
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+  pdf2svg
 
 ARG asciidoctor_confluence_version=0.0.2
 ARG asciidoctor_diagram_version=2.3.1

--- a/tests/fixtures/sample-with-diagram.adoc
+++ b/tests/fixtures/sample-with-diagram.adoc
@@ -251,3 +251,18 @@ A31117013206375A
 ....
 Hello World!
 ....
+
+=== TikZ
+https://tikz.net/
+
+[tikz]
+....
+\begin{tikzpicture}
+
+\draw (-2,0) -- (2,0);
+\filldraw [gray] (0,0) circle (2pt);
+\draw (-2,-2) .. controls (0,0) .. (2,-2);
+\draw (-2,2) .. controls (-1,0) and (1,0) .. (2,2);
+
+\end{tikzpicture}
+....


### PR DESCRIPTION
asciidoctor-diagram expects texlive, texmf-dist-latexextra and pdf2svg to be installed in order to build TikZ diagrams.
This PR:

    adds a TikZ section in asciidoctor-diagram adoc example for tests.
    installs texlive, texmf-dist-latexextra
    installs pdf2svg from alpine/edge/testing

