### PR TITLE
Feature/rubyeval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ ARG kramdown_asciidoc_version=2.1.0
 ARG asciidoctor_bibtex_version=0.9.0
 ARG asciidoctor_kroki_version=0.10.0
 ARG asciidoctor_reducer_version=1.0.2
+ARG asciidoctor_rubyeval_version=1.0.0
 ARG barby_version=0.6.8
 ARG rqrcode_version=2.2.0
 ARG chunky_png_version=1.4.0
@@ -115,6 +116,7 @@ ENV ASCIIDOCTOR_CONFLUENCE_VERSION=${asciidoctor_confluence_version} \
   ASCIIDOCTOR_BIBTEX_VERSION=${asciidoctor_bibtex_version} \
   ASCIIDOCTOR_KROKI_VERSION=${asciidoctor_kroki_version} \
   ASCIIDOCTOR_REDUCER_VERSION=${asciidoctor_reducer_version} \
+  ASCIIDOCTOR_RUBYEVAL_VERSION=${asciidoctor_rubyeval_version} \
   BARBY_VERSION=${barby_version} \
   RQRCODE_VERSION=${rqrcode_version} \
   CHUNKY_PNG_VERSION=${chunky_png_version}
@@ -133,6 +135,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
   "asciidoctor-mathematical:${ASCIIDOCTOR_MATHEMATICAL_VERSION}" \
   asciimath \
   "asciidoctor-revealjs:${ASCIIDOCTOR_REVEALJS_VERSION}" \
+  "asciidoctor-rubyeval:${ASCIIDOCTOR_RUBYEVAL_VERSION}" \
   coderay \
   epubcheck-ruby:4.2.4.0 \
   haml \

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,7 @@
 :ASCIIDOCTOR_BIBTEX_VERSION: 0.9.0
 :ASCIIDOCTOR_KROKI_VERSION: 0.10.0
 :ASCIIDOCTOR_REDUCER_VERSION: 1.0.2
+:ASCIIDOCTOR_RUBYEVAL_VERSION: 1.0.0
 = Asciidoctor Docker Container
 :source-highlighter: coderay
 
@@ -36,6 +37,7 @@ This Docker image provides:
 * https://github.com/asciidoctor/asciidoctor-bibtex[Asciidoctor Bibtex] {ASCIIDOCTOR_BIBTEX_VERSION}
 * https://github.com/Mogztter/asciidoctor-kroki[Asciidoctor Kroki] {ASCIIDOCTOR_KROKI_VERSION}
 * https://github.com/asciidoctor/asciidoctor-reducer[Asciidoctor Reducer] {ASCIIDOCTOR_REDUCER_VERSION}
+* https://gitlab.com/defmastership/asciidoctor-rubyeval[Asciidoctor Rubyeval] {ASCIIDOCTOR_RUBYEVAL_VERSION}
 
 This image uses Alpine Linux {ALPINE_VERSION} as base image.
 

--- a/tests/asciidoctor.bats
+++ b/tests/asciidoctor.bats
@@ -307,3 +307,13 @@ teardown() {
 
   grep 'Mane' ${TMP_GENERATION_DIR}/sample-with-bib.html
 }
+
+@test "We can generate HTML documents with ruby evaluations" {
+  run docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
+      asciidoctor --trace -D /documents/tmp -r asciidoctor-rubyeval \
+      /documents/fixtures/sample-with-rubyeval.adoc
+
+  [ "${status}" -eq 0 ]
+}

--- a/tests/fixtures/sample-with-rubyeval.adoc
+++ b/tests/fixtures/sample-with-rubyeval.adoc
@@ -1,0 +1,9 @@
+= Rubyeval
+
+(See https://gitlab.com/defmastership/asciidoctor-rubyeval)
+
+This is just an Asciidoctor inline  macro extension to eval statements with ruby:
+
+:my_str: hello, world !
+
+I am an inline rubyeval::['{my_str}'.upcase]


### PR DESCRIPTION
Include `asciidcotor-rubyeval`  inline macro allowing to include some ruby statement evaluated at rendering time.
this is a really simple gem, mainly based on the comments of https://github.com/asciidoctor/asciidoctor/issues/3053.

The statements have the following pattern:

```
:my_str: hello, world !

I am an inline rubyeval::['{my_str}'.upcase]
```
To avoid unsafe code injections, the statements are filtered thanks to the [safe_ruby](https://gitlab.com/defmastership/safe_ruby) gem.
