### PR TITLE
chore(epubcheck-ruby) Use up-to-date (latest) epubcheck-ruby instead of pinned version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
   asciimath \
   "asciidoctor-revealjs:${ASCIIDOCTOR_REVEALJS_VERSION}" \
   coderay \
-  epubcheck-ruby:4.2.4.0 \
+  epubcheck-ruby \
   haml \
   "kramdown-asciidoc:${KRAMDOWN_ASCIIDOC_VERSION}" \
   pygments.rb \


### PR DESCRIPTION
Possibly fixes #495. #495 doesn't say what exact vulnerability they detected, but most likely it is CVE-2021-23792, and we will get the fix through https://github.com/w3c/epubcheck/commit/50b847f345583400d84c35f7b8acb273048f7920 that is included in epubcheck-ruby 5.0.0 and newer.