### PR TITLE
chore: upgrade Java to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN apk add --no-cache \
   graphviz \
   inotify-tools \
   make \
-  openjdk17-jre \
+  openjdk21-jre \
   python3 \
   py3-cairo \
   py3-setuptools \


### PR DESCRIPTION
fix #525

Before the change:

```console
$ docker run --rm -it asciidoctor:latest java -version 
openjdk version "17.0.15" 2025-04-15
OpenJDK Runtime Environment (build 17.0.15+6-alpine-r0)
OpenJDK 64-Bit Server VM (build 17.0.15+6-alpine-r0, mixed mode, sharing)
```

After the change:

```console
$ docker run --rm -it asciidoctor:latest java -version
openjdk version "21.0.7" 2025-04-15
OpenJDK Runtime Environment (build 21.0.7+6-alpine-r0)
OpenJDK 64-Bit Server VM (build 21.0.7+6-alpine-r0, mixed mode, sharing)
               
```

`make test` ran successfully; `tests/fixtures/sample-with-diagram.adoc` contains a PlantUML diagram, i.e. using the upgraded Java version.

Related: https://github.com/asciidoctor/docker-asciidoctor/issues/44#issuecomment-1051881756