### PR TITLE
Add optimise support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
   thread_safe \
   tilt \
   text-hyphen \
+  rghost \
   "asciidoctor-bibtex:${ASCIIDOCTOR_BIBTEX_VERSION}" \
   "asciidoctor-kroki:${ASCIIDOCTOR_KROKI_VERSION}" \
   "asciidoctor-reducer:${ASCIIDOCTOR_REDUCER_VERSION}" \

--- a/tests/asciidoctor.bats
+++ b/tests/asciidoctor.bats
@@ -124,6 +124,14 @@ teardown() {
       /documents/fixtures/basic-example.adoc
 }
 
+@test "We can generate an optimized PDF document from basic example" {
+  docker run -t --rm \
+    -v "${BATS_TEST_DIRNAME}":/documents/ \
+    "${DOCKER_IMAGE_NAME_TO_TEST}" \
+      asciidoctor-pdf -a optimize=printer -D /documents/tmp -r asciidoctor-mathematical \
+      --failure-level WARN \
+      /documents/fixtures/basic-example.adoc
+}
 @test "We can generate an FB2 document from basic example without errors/warnings" {
 
   docker run -t --rm \


### PR DESCRIPTION
Without this, the -a optimise on asciidoctor-pdf will fail with the following message:

asciidoctor: WARNING: optional gem 'rghost' is not available. Functionality disabled.

This is a problem, as it prevents the one-liners optimisations, and requires the users to use a separate gs call.

This fixes it by ensuring rghost is present in the container and adds tests to guarantee it is working in the future.