### PR TITLE
Bump asciidoctor-diagram-plantuml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ RUN apk add --no-cache --virtual .rubymakedepends \
   # TODO: track with updatecli
   "asciidoctor-diagram-ditaamini:1.0.3" `# Used by asciidoctor-diagram` \
   # TODO: track with updatecli
-  "asciidoctor-diagram-plantuml:1.2025.2" `# Used by asciidoctor-diagram` \
+  "asciidoctor-diagram-plantuml:1.2026.2" `# Used by asciidoctor-diagram` \
   "asciidoctor-epub3:${ASCIIDOCTOR_EPUB3_VERSION}" \
   "asciidoctor-fb2:${ASCIIDOCTOR_FB2_VERSION}" \
   "asciidoctor-mathematical:${ASCIIDOCTOR_MATHEMATICAL_VERSION}" \


### PR DESCRIPTION
Bump from 1.2025.2 to 1.2026.2
This is related to https://github.com/asciidoctor/asciidoctor-diagram/issues/512, where certain PlantUML syntax raised a syntax error when using the docker image. It works in the PlantUML online editor and the project's maintainer says it works with a local installation. I tested these changes locally and with them, it also works in the docker container.