### PR TITLE
chore(updatecli) fix asciidoctor-diagram manifest

### DIFF
--- a/updatecli/updatecli.d/asciidoctor-diagram.yml
+++ b/updatecli/updatecli.d/asciidoctor-diagram.yml
@@ -12,18 +12,16 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       branch: "{{ .github.branch }}"
-  asciidoctor-diagram:
-    kind: git
-    spec:
-      url: https://github.com/asciidoctor/asciidoctor-diagram
-      branch: master
 
 sources:
   latestVersion:
-    kind: gittag
-    name: "Get the latest Asciidoctor-Diagram version from latest git tag (no GitHub release)"
-    scmid: asciidoctor-diagram
+    kind: githubrelease
+    name: "Get the latest Asciidoctor-Diagram version from its GitHub Releases"
     spec:
+      owner: asciidoctor
+      repository: asciidoctor-diagram
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
       versionfilter:
         kind: latest
     transformers:


### PR DESCRIPTION
The asciidoctor-diagram repository is now publishing GitHub releases and does not have a `master` branch anymore.

Let's fix the `updatecli` manifest which tracks the `asciidoctor-diagram` Gem version to use GitHub release instead of git tags.